### PR TITLE
"Page Content" Event Card Large

### DIFF
--- a/libs/design-system/src/lib/Components/EventCard/EventCard.stories.tsx
+++ b/libs/design-system/src/lib/Components/EventCard/EventCard.stories.tsx
@@ -25,5 +25,5 @@ Default.args = {
     'https://assets.website-files.com/5f6294c0c7a8cdf432b1c827/61689102d3325e237fd44b76_unnamed%20(8).png',
   tags: ['Flow official'],
   title: 'Event Title',
-  when: 'Mar 23',
+  eventDate: 'Mar 23',
 };

--- a/libs/design-system/src/lib/Components/EventCard/index.tsx
+++ b/libs/design-system/src/lib/Components/EventCard/index.tsx
@@ -10,7 +10,7 @@ export type EventCardProps = {
   imageSrc: string;
   tags?: string[];
   title: string;
-  when: string;
+  eventDate: string;
 };
 
 export function EventCard({
@@ -22,13 +22,13 @@ export function EventCard({
   eventType = 'Online',
   tags,
   title,
-  when,
+  eventDate,
 }: EventCardProps) {
   return (
     <div className="flex min-h-fit flex-col-reverse overflow-hidden rounded-2xl bg-white dark:bg-primary-dark-gray md:min-h-[30rem] md:flex-row">
       <div className="min-w-[50%] flex-1 basis-1/2 self-center py-10 pl-6 pr-6 md:pr-32 md:pl-20">
         <div className="divide-x divide-solid divide-primary-gray-200 text-primary-gray-300">
-          <span className="pr-2">{when}</span>
+          <span className="pr-2">{eventDate}</span>
           <span className="pl-2">{eventType}</span>
         </div>
         <h3 className="text-h3 mb-2 md:mb-3">{title}</h3>


### PR DESCRIPTION
# Adds Event Card

<img width="1350" alt="Screen Shot 2022-05-31 at 2 49 28 PM" src="https://user-images.githubusercontent.com/393220/171264195-dad7136e-5ea9-4cc7-9db2-eb0c074b07c8.png">

<img width="1405" alt="Screen Shot 2022-05-31 at 1 41 54 PM" src="https://user-images.githubusercontent.com/393220/171264270-e92f9df5-3c35-4cc4-ae00-bc08607b07e1.png">

<img width="339" alt="Screen Shot 2022-05-31 at 2 49 43 PM" src="https://user-images.githubusercontent.com/393220/171264291-9ef46905-6158-4d21-b33e-a9dfaea5c128.png">

<img width="343" alt="Screen Shot 2022-05-31 at 2 49 48 PM" src="https://user-images.githubusercontent.com/393220/171264294-d8e23b64-749f-4fa7-96f0-8f280727899a.png">

The designs show the CTA button missing on the mobile view. It's not clear if that's intentional, because that would leave no way to click through to the event. Unless the entire card or event title is meant to be clickable? Is this the sort of thing we can go back and address later during page implementation? Or is it something we need to get nailed down here?

---
Closes #69 