### PR TITLE
Add divided-item-hover helper

### DIFF
--- a/libs/design-system/src/lib/Components/LinkCard3Column/index.tsx
+++ b/libs/design-system/src/lib/Components/LinkCard3Column/index.tsx
@@ -25,7 +25,7 @@ export type LinkCard3ColumnProps = {
 
 export function LinkCard3Column({ items }: LinkCard3ColumnProps) {
   return (
-    <div className="grid grid-cols-1 gap-x-4 rounded-lg bg-white pb-8 dark:bg-primary-dark-gray md:grid-cols-3 md:flex-row">
+    <div className="grid grid-cols-1 pb-8 bg-white rounded-lg gap-x-4 dark:bg-primary-dark-gray md:grid-cols-3 md:flex-row">
       {items.map((item, index) => (
         <div
           key={`${item.title}-header`}
@@ -38,7 +38,7 @@ export function LinkCard3Column({ items }: LinkCard3ColumnProps) {
             'grid-column-start-3': index === 2,
           })}
         >
-          <h5 className="text-h5 mb-2 flex items-center">
+          <h5 className="flex items-center mb-2 text-h5">
             {item.icon && <span className="mr-2">{item.icon}</span>}{' '}
             {item.title}
           </h5>
@@ -50,43 +50,42 @@ export function LinkCard3Column({ items }: LinkCard3ColumnProps) {
       {items.map((item, index) => (
         <div
           key={`${item.title}-content`}
-          className={clsx('px-6 md:row-start-2 md:pb-8', {
-            'row-start-2': index === 0,
-            'row-start-4': index === 1,
-            'row-start-6': index === 2,
-          })}
+          className={clsx(
+            'divide-y divide-primary-gray-100 px-6 md:row-start-2 md:pb-8',
+            {
+              'row-start-2': index === 0,
+              'row-start-4': index === 1,
+              'row-start-6': index === 2,
+            }
+          )}
         >
-          {item.links?.map((link, index) => (
-            <a
-              key={link.title}
-              className="link-card-3-column-link group flex flex-col rounded-lg px-4 hover:bg-primary-gray-200"
-              href={link.href}
-            >
-              <span
-                className={clsx('display-block py-4', {
-                  'border-t border-t-primary-gray-200 dark:border-t-primary-gray-300 dark:group-hover:border-t-primary-gray-200':
-                    index > 0,
-                })}
+          {item.links?.map((link) => (
+            <div key={link.title} className="divided-item-hover">
+              <a
+                className="flex flex-col px-4 rounded-lg link-card-3-column-link group hover:bg-primary-gray-50"
+                href={link.href}
               >
-                <span className="flex justify-between">
-                  <span className="group-hover:text-primary-blue">
-                    {link.title}
+                <span className="py-4 display-block">
+                  <span className="flex justify-between">
+                    <span className="group-hover:text-primary-blue">
+                      {link.title}
+                    </span>
+                    <span className="pt-1 dark:group-hover:text-black">
+                      {isLinkExternal(link.href) ? (
+                        <ExternalLinkIcon height="16" />
+                      ) : (
+                        <ChevronRight height="16" />
+                      )}
+                    </span>
                   </span>
-                  <span className="pt-1 dark:group-hover:text-black">
-                    {isLinkExternal(link.href) ? (
-                      <ExternalLinkIcon height="16" />
-                    ) : (
-                      <ChevronRight height="16" />
-                    )}
+                  <span>
+                    {link.tags?.map((tag) => (
+                      <Tag key={tag} name={tag} />
+                    ))}
                   </span>
                 </span>
-                <span>
-                  {link.tags?.map((tag) => (
-                    <Tag key={tag} name={tag} />
-                  ))}
-                </span>
-              </span>
-            </a>
+              </a>
+            </div>
           ))}
         </div>
       ))}

--- a/libs/design-system/styles/main.css
+++ b/libs/design-system/styles/main.css
@@ -54,6 +54,8 @@ ul.contains-task-list {
   @apply relative pl-8 mt-3;
 }
 
-.link-card-3-column-link:hover + .link-card-3-column-link > span {
-  border-top-color: transparent;
+/* Add .divided-item-hover to .divide-y children to hide borders on hover */
+.divided-item-hover:hover,
+.divided-item-hover:hover + .divided-item-hover {
+  @apply !border-transparent;
 }


### PR DESCRIPTION
.divided-item-hover hides borders on hover when using the tailwind divide helpers

```
<div className="divide-y divide-border-primary-gray-50">
   <div className="divided-item-hover">item</div>
   <div className="divided-item-hover">item</div>
   <div className="divided-item-hover">item</div>
</div>
```
