### PR TITLE
Updated Event Card

### DIFF
--- a/libs/design-system/src/lib/Components/EventCard/EventCard.stories.tsx
+++ b/libs/design-system/src/lib/Components/EventCard/EventCard.stories.tsx
@@ -1,12 +1,17 @@
 import { Meta, Story } from '@storybook/react';
-import { EventCard, EventCardProps } from '.';
+import {
+  EventCard,
+  EventCardList,
+  EventCardProps,
+  EventCardListProps,
+} from '.';
 
 export default {
   component: EventCard,
   title: 'Components/EventCard',
 } as Meta;
 
-const Template: Story<EventCardProps> = (args) => {
+const TemplateSingle: Story<EventCardProps> = (args) => {
   return (
     <div style={{ backgroundColor: '#f1f1f1', padding: '14px' }}>
       <EventCard {...args} />
@@ -14,7 +19,7 @@ const Template: Story<EventCardProps> = (args) => {
   );
 };
 
-export const Default = Template.bind({});
+export const Default = TemplateSingle.bind({});
 Default.args = {
   ctaText: 'CTA text',
   description:
@@ -26,4 +31,72 @@ Default.args = {
   location: 'Online',
   tags: ['Flow official'],
   title: 'Event Title',
+};
+
+const TemplateList: Story<EventCardListProps> = (args) => {
+  return (
+    <div style={{ backgroundColor: '#f1f1f1', padding: '14px' }}>
+      <EventCardList {...args} />
+    </div>
+  );
+};
+
+export const EventList = TemplateList.bind({});
+EventList.args = {
+  events: [
+    {
+      ctaText: 'CTA text',
+      description:
+        'Everything you need to start building on Flow verything you need to start building on Flow everything you need to start building on Flow.',
+      eventDate: 'Mar 23',
+      href: '#changeme',
+      imageSrc:
+        'https://assets.website-files.com/5f6294c0c7a8cdf432b1c827/61689102d3325e237fd44b76_unnamed%20(8).png',
+      location: 'Online',
+      tags: ['Flow official'],
+      title: 'Event Title',
+    },
+    {
+      ctaText: 'CTA text',
+      description:
+        'Everything you need to start building on Flow verything you need to start building on Flow everything you need to start building on Flow.',
+      eventDate: 'Mar 23',
+      href: '#changeme',
+      imageSrc:
+        'https://assets.website-files.com/5f6294c0c7a8cdf432b1c827/6260a0a79495531831a4114e_kitty%20items.jpg',
+      location: 'Online',
+      tags: ['Flow official'],
+      title: 'A second event',
+    },
+    {
+      ctaText: 'CTA text',
+      description:
+        'Everything you need to start building on Flow verything you need to start building on Flow everything you need to start building on Flow.',
+      eventDate: 'Mar 23',
+      href: '#changeme',
+      imageSrc:
+        'https://assets.website-files.com/5f6294c0c7a8cdf432b1c827/62728fcb139292a43a6b082b_flovatar-may4.jpg',
+      location: 'Online',
+      tags: ['Flow official'],
+      title: 'A third event',
+    },
+  ],
+};
+
+export const EventListSingle = TemplateList.bind({});
+EventListSingle.args = {
+  events: [
+    {
+      ctaText: 'CTA text',
+      description:
+        'Everything you need to start building on Flow verything you need to start building on Flow everything you need to start building on Flow.',
+      eventDate: 'Mar 23',
+      href: '#changeme',
+      imageSrc:
+        'https://assets.website-files.com/5f6294c0c7a8cdf432b1c827/61689102d3325e237fd44b76_unnamed%20(8).png',
+      location: 'Online',
+      tags: ['Flow official'],
+      title: 'Event Title',
+    },
+  ],
 };

--- a/libs/design-system/src/lib/Components/EventCard/EventCard.stories.tsx
+++ b/libs/design-system/src/lib/Components/EventCard/EventCard.stories.tsx
@@ -16,14 +16,14 @@ const Template: Story<EventCardProps> = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  buttonText: 'CTA text',
-  buttonUrl: '#changeme',
+  ctaText: 'CTA text',
   description:
     'Everything you need to start building on Flow verything you need to start building on Flow everything you need to start building on Flow.',
-  eventType: 'Online',
+  eventDate: 'Mar 23',
+  href: '#changeme',
   imageSrc:
     'https://assets.website-files.com/5f6294c0c7a8cdf432b1c827/61689102d3325e237fd44b76_unnamed%20(8).png',
+  location: 'Online',
   tags: ['Flow official'],
   title: 'Event Title',
-  eventDate: 'Mar 23',
 };

--- a/libs/design-system/src/lib/Components/EventCard/index.tsx
+++ b/libs/design-system/src/lib/Components/EventCard/index.tsx
@@ -1,7 +1,10 @@
+import clsx from 'clsx';
 import { ButtonLink } from '../Button';
+import { MobileCarousel } from '../MobileCarousel';
 import Tag from '../Tag';
 
 export type EventCardProps = {
+  className?: string;
   ctaText: string;
   description: string;
   eventDate: string;
@@ -14,6 +17,7 @@ export type EventCardProps = {
 };
 
 export function EventCard({
+  className,
   ctaText,
   description,
   eventDate,
@@ -25,8 +29,13 @@ export function EventCard({
   title,
 }: EventCardProps) {
   return (
-    <div className="flex min-h-fit flex-col-reverse overflow-hidden rounded-2xl bg-white dark:bg-primary-dark-gray md:min-h-[30rem] md:flex-row">
-      <div className="min-w-[50%] flex-1 basis-1/2 self-center py-10 pl-6 pr-6 md:pr-32 md:pl-20">
+    <div
+      className={clsx(
+        'flex min-h-fit flex-col-reverse overflow-hidden rounded-2xl bg-white dark:bg-primary-dark-gray md:min-h-[30rem] md:flex-row',
+        className
+      )}
+    >
+      <div className="min-w-[50%] flex-none basis-1/2 self-center py-10 pl-6 pr-6 md:pr-32 md:pl-20">
         <div className="divide-x divide-solid divide-primary-gray-200 text-primary-gray-300">
           <span className="pr-2">{eventDate}</span>
           <span className="pl-2">{location}</span>
@@ -50,7 +59,7 @@ export function EventCard({
           {ctaText}
         </ButtonLink>
       </div>
-      <div className="flex-1 basis-1/2 self-stretch">
+      <div className="flex-none basis-1/2 self-stretch">
         <img
           src={imageSrc}
           alt={imageAlt}
@@ -58,5 +67,19 @@ export function EventCard({
         />
       </div>
     </div>
+  );
+}
+
+export type EventCardListProps = {
+  events: EventCardProps[];
+};
+
+export function EventCardList({ events }: EventCardListProps) {
+  return (
+    <MobileCarousel>
+      {events.map((event) => (
+        <EventCard key={`${event.title}-${event.href}`} {...event} />
+      ))}
+    </MobileCarousel>
   );
 }

--- a/libs/design-system/src/lib/Components/EventCard/index.tsx
+++ b/libs/design-system/src/lib/Components/EventCard/index.tsx
@@ -2,36 +2,38 @@ import { ButtonLink } from '../Button';
 import Tag from '../Tag';
 
 export type EventCardProps = {
-  buttonText: string;
-  buttonUrl: string;
+  ctaText: string;
   description: string;
-  eventType: string;
+  eventDate: string;
+  href: string;
   imageAlt?: string;
   imageSrc: string;
+  location: string;
   tags?: string[];
   title: string;
-  eventDate: string;
 };
 
 export function EventCard({
-  buttonText,
-  buttonUrl,
+  ctaText,
   description,
+  eventDate,
+  href,
   imageAlt = '',
   imageSrc,
-  eventType = 'Online',
+  location = 'Online',
   tags,
   title,
-  eventDate,
 }: EventCardProps) {
   return (
     <div className="flex min-h-fit flex-col-reverse overflow-hidden rounded-2xl bg-white dark:bg-primary-dark-gray md:min-h-[30rem] md:flex-row">
       <div className="min-w-[50%] flex-1 basis-1/2 self-center py-10 pl-6 pr-6 md:pr-32 md:pl-20">
         <div className="divide-x divide-solid divide-primary-gray-200 text-primary-gray-300">
           <span className="pr-2">{eventDate}</span>
-          <span className="pl-2">{eventType}</span>
+          <span className="pl-2">{location}</span>
         </div>
-        <h3 className="text-h3 mb-2 md:mb-3">{title}</h3>
+        <h3 className="text-h3 mb-2 md:mb-3">
+          <a href={href}>{title}</a>
+        </h3>
         {tags && tags.length > 0 && (
           <div>
             {tags.map((tag) => (
@@ -41,11 +43,11 @@ export function EventCard({
         )}
         <p className="mt-3 pb-6 dark:text-primary-gray-100">{description}</p>
         <ButtonLink
-          href={buttonUrl}
+          href={href}
           variant="primary-inverse"
           className="whitespace-nowrap px-16 py-4 text-center"
         >
-          {buttonText}
+          {ctaText}
         </ButtonLink>
       </div>
       <div className="flex-1 basis-1/2 self-stretch">

--- a/libs/design-system/src/lib/Components/MobileCarousel/MobileCarousel.stories.tsx
+++ b/libs/design-system/src/lib/Components/MobileCarousel/MobileCarousel.stories.tsx
@@ -1,0 +1,39 @@
+import { Meta, Story } from '@storybook/react';
+import { MobileCarousel, MobileCarouselProps } from '.';
+
+export default {
+  component: MobileCarousel,
+  title: 'Components/MobileCarousel',
+} as Meta;
+
+const TemplateSingle: Story<MobileCarouselProps> = (args) => {
+  return (
+    <div style={{ backgroundColor: '#f1f1f1', padding: '14px' }}>
+      <MobileCarousel {...args} />
+    </div>
+  );
+};
+
+export const Default = TemplateSingle.bind({});
+Default.args = {
+  children: [
+    <div
+      key={1}
+      style={{ backgroundColor: '#ff0000', height: '20rem', width: '100%' }}
+    >
+      Item 1
+    </div>,
+    <div
+      key={2}
+      style={{ backgroundColor: '#00ff00', height: '20rem', width: '100%' }}
+    >
+      Item 2
+    </div>,
+    <div
+      key={3}
+      style={{ backgroundColor: '#0000ff', height: '20rem', width: '100%' }}
+    >
+      Item 3
+    </div>,
+  ],
+};

--- a/libs/design-system/src/lib/Components/MobileCarousel/index.tsx
+++ b/libs/design-system/src/lib/Components/MobileCarousel/index.tsx
@@ -1,0 +1,79 @@
+import clsx from 'clsx';
+import React, { useCallback, useRef, useState } from 'react';
+
+export type MobileCarouselProps = React.PropsWithChildren<unknown>;
+
+/**
+ * A Carousel that allows scrolling through it's children horizontally and
+ * individually, but in larger screens (md+) shows all children stacked
+ * vertically.
+ */
+export function MobileCarousel({ children }: MobileCarouselProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const scrollContainer = useRef<HTMLUListElement>();
+  const childCount = React.Children.count(children);
+
+  const onScrollHandler = useCallback<React.UIEventHandler<HTMLUListElement>>(
+    (e) => {
+      const { scrollWidth, scrollLeft } = e.currentTarget;
+      const index = Math.round((scrollLeft / scrollWidth) * childCount);
+      setSelectedIndex(index);
+    },
+    [childCount]
+  );
+
+  return (
+    <section className="flex flex-col">
+      <ul
+        className="flex min-h-fit snap-x snap-mandatory list-none flex-row gap-6 overflow-x-auto md:flex-col"
+        onScroll={onScrollHandler}
+        ref={scrollContainer}
+      >
+        {React.Children.map(children, (child, index) => (
+          <li
+            key={index}
+            className={clsx('flex-none snap-start md:w-full', {
+              'w-10/12': childCount > 1,
+              'w-full': childCount <= 1,
+            })}
+          >
+            {child}
+          </li>
+        ))}
+      </ul>
+      <ul
+        className={clsx(
+          'flex list-none flex-row justify-center pt-3 md:hidden',
+          {
+            hidden: childCount <= 1,
+          }
+        )}
+        role="listbox"
+      >
+        {React.Children.map(children, (_, index) => (
+          <button
+            key={index}
+            type="button"
+            role="option"
+            aria-selected={index === selectedIndex ? 'true' : 'false'}
+            className={clsx(
+              'mr-3 h-3 h-4 w-3 w-4 rounded-full hover:cursor-pointer',
+              {
+                'bg-green-success': index === selectedIndex,
+                'bg-primary-gray-100': index !== selectedIndex,
+              }
+            )}
+            onClick={(e) => {
+              const { current } = scrollContainer;
+
+              current?.scrollTo({
+                left: current?.scrollWidth * (index / childCount),
+                behavior: 'smooth',
+              });
+            }}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
- Adds a generic `MobileCarousel` component that should be reusable in these cases where we want a vertical stack to become a horizontal carousel on mobile screens.
- Adds `EventCardList` component for rendering multiple events (uses the `MobileCarousel` component mentioned above)
- In `EventCard`: 
  - Makes the title clickable
  - Renames `buttonUrl` prop to `href`
  - Renames `buttonText` prop to `ctaText` (to match existing prop names)
  - Renames `eventType` prop to `location` (I think that's what this is meant to indicate?)

This is what the mobile version of the `EventCardList` looks like:

<img width="381" alt="Screen Shot 2022-06-01 at 3 41 55 PM" src="https://user-images.githubusercontent.com/393220/171488408-f080520e-d0bc-4451-81f4-83eb49937d1e.png">

