### PR TITLE
3 Column Link Card

### DIFF
--- a/libs/design-system/src/lib/Components/LandingHeader/index.tsx
+++ b/libs/design-system/src/lib/Components/LandingHeader/index.tsx
@@ -10,6 +10,7 @@ export type LandingHeaderProps = {
   title: string;
 };
 
+// !text-4xl md:!text-7xl
 export function LandingHeader({
   buttonText,
   buttonUrl,

--- a/libs/design-system/src/lib/Components/LandingHeader/index.tsx
+++ b/libs/design-system/src/lib/Components/LandingHeader/index.tsx
@@ -10,7 +10,6 @@ export type LandingHeaderProps = {
   title: string;
 };
 
-// !text-4xl md:!text-7xl
 export function LandingHeader({
   buttonText,
   buttonUrl,

--- a/libs/design-system/src/lib/Components/LinkCard3Column/LinkCard3Column.stories.tsx
+++ b/libs/design-system/src/lib/Components/LinkCard3Column/LinkCard3Column.stories.tsx
@@ -1,0 +1,203 @@
+import { Meta, Story } from '@storybook/react';
+import { LinkCard3Column, LinkCard3ColumnProps } from '.';
+
+const Icon1 = () => (
+  <svg
+    width="38"
+    height="42"
+    viewBox="0 0 38 42"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M15.543 22.4783V18.8572L18.9988 16.9147L22.4545 18.8572V22.4783L18.9988 24.4208L15.543 22.4783Z"
+      stroke="#69717E"
+      stroke-width="0.5"
+    />
+    <path d="M16 22V19.5L18.5 21V23.5L16 22Z" fill="#69717E" stroke="#69717E" />
+    <path
+      d="M11.6768 16.6911L18.9498 12.4414L26.3221 16.6921V24.957L18.9497 29.1318L11.6768 24.958V16.6911Z"
+      stroke="#69717E"
+      stroke-width="0.5"
+    />
+    <path
+      d="M8.22657 14.6674L18.9998 8.60136L29.7731 14.6674V26.634L18.9998 32.6499L8.22656 26.634L8.22657 14.6674Z"
+      stroke="#69717E"
+      stroke-width="0.5"
+    />
+    <path
+      d="M11.5889 16.6191L8.20522 14.6755"
+      stroke="#69717E"
+      stroke-width="0.5"
+    />
+    <path
+      d="M26.3965 16.6279L29.8747 14.6297"
+      stroke="#69717E"
+      stroke-width="0.5"
+    />
+    <path d="M19 29.1855L19 32.6758" stroke="#69717E" stroke-width="0.5" />
+    <path
+      d="M33.1797 12.7314L36.8855 10.6025"
+      stroke="#69717E"
+      stroke-width="0.5"
+    />
+    <path
+      d="M4.82031 12.7314L1.11453 10.6025"
+      stroke="#69717E"
+      stroke-width="0.5"
+    />
+    <path
+      d="M4.87767 12.7761L18.9998 4.764L33.1218 12.7761V28.7929L18.9998 36.805L4.87767 28.7929V12.7761Z"
+      stroke="#69717E"
+      stroke-width="0.5"
+    />
+    <path
+      d="M1.25 10.6294L19 0.289326L36.75 10.6294V31.0326L19 41.2805L1.25 31.0326L1.25 10.6294Z"
+      stroke="#69717E"
+      stroke-width="0.5"
+    />
+  </svg>
+);
+
+const Icon2 = () => (
+  <svg
+    width="33"
+    height="37"
+    viewBox="0 0 33 37"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M1.02727 27.9036L16.7178 36.7266L31.6204 28.1226L32.8176 9.55968L16.8366 0.237935L0.944936 9.41299L1.02727 27.9036ZM9.52072 5.11211L1.78834 9.57641L7.95206 13.1717L15.7803 8.65211L9.52072 5.11211ZM10.0869 4.78524L16.8351 0.889131L22.9989 4.48445L16.3464 8.32524L10.0869 4.78524ZM16.9155 8.64706L23.5592 4.81129L31.9643 9.71399L25.4512 13.4743L16.9155 8.64706ZM25.7302 13.9636L32.2104 10.2222L31.5787 20.0171L25.4914 23.5316L25.7302 13.9636ZM24.9198 23.8617L25.1586 14.2936L17.1965 18.8905L17.0893 28.3331L17.133 28.3574L24.9198 23.8617ZM25.475 24.1915L31.5352 20.6926L31.0777 27.7855L25.3021 31.1201L25.475 24.1915ZM24.7304 31.4501L24.9033 24.5215L17.1384 29.0046L17.082 28.9733L17.0032 35.9114L24.7304 31.4501ZM24.885 13.8012L16.3493 8.97393L8.5124 13.4986L16.9175 18.4013L24.885 13.8012ZM8.30518 14.0297L16.6333 18.8875L16.5295 28.0224L8.34726 23.4801L8.30518 14.0297ZM8.35014 24.1259L16.5223 28.6625L16.4398 35.924L8.3825 31.3934L8.35014 24.1259ZM7.81785 31.0759L7.78551 23.8125L1.55689 20.3547L1.58903 27.5734L7.81785 31.0759ZM1.55401 19.7089L7.78263 23.1667L7.74048 13.7004L1.51108 10.0667L1.55401 19.7089Z"
+      fill="#69717E"
+    />
+  </svg>
+);
+
+const Icon3 = () => (
+  <svg
+    width="36"
+    height="41"
+    viewBox="0 0 36 41"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M4.53199e-07 9.64258L18 20.2497V40.4997L0 30.214L4.53199e-07 9.64258Z"
+      fill="#69717E"
+    />
+    <path
+      d="M35.5 29.9241L18.5 39.6384V20.25V19.9643L18.2538 19.8192L1.02007 9.66362L18 0.567228L35.5 9.94223V29.9241Z"
+      stroke="#69717E"
+    />
+  </svg>
+);
+
+export default {
+  component: LinkCard3Column,
+  title: 'Components/LinkCard3Column',
+} as Meta;
+
+const Template: Story<LinkCard3ColumnProps> = (args) => {
+  return (
+    <div style={{ backgroundColor: '#f1f1f1', padding: '14px' }}>
+      <LinkCard3Column {...args} />
+    </div>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  buttonText: 'Get Started',
+  buttonUrl: '#changeme',
+  description:
+    'Building on Flow is easy. Start building now with lorem ipsum et sigitus loranum prospitarius.',
+  title: 'Start Your Project',
+  tags: ['Tag', 'Lorem', 'Ipsum'],
+  items: [
+    {
+      title: 'Quickstart',
+      description:
+        'A package used to interact with user wallets and the Flow blockchain.',
+      icon: <Icon1 />,
+      links: [
+        {
+          title: 'Quickstart tutorial',
+          href: '#tutorial1',
+          tags: ['tutorial'],
+        },
+        {
+          title: 'Name of a tutorial',
+          href: '#tutorial2',
+          tags: ['tutorial'],
+        },
+        {
+          title: 'Name of another tutorial',
+          href: '#tutorial3',
+          tags: ['tutorial'],
+        },
+      ],
+    },
+    {
+      title: 'Guides & Tutorials',
+      description:
+        'An up to 3-line blurb here describing the section lorem ipsum dolor sit amet proin.',
+      icon: <Icon2 />,
+      links: [
+        {
+          title: 'Guide 1',
+          href: '#tutorial1',
+          tags: ['tutorial'],
+        },
+        {
+          title: 'Guide 2',
+          href: '#tutorial2',
+        },
+        {
+          title: 'An external link',
+          href: 'https://www.onflow.org',
+          tags: ['tutorial', 'external'],
+        },
+      ],
+    },
+    {
+      title: 'Smart Contracts',
+      description: 'Smart contracts description.',
+      icon: <Icon3 />,
+      links: [
+        {
+          title: 'Name of a Smart Contract tutorial',
+          href: '#tutorial1',
+          tags: ['tutorial'],
+        },
+        {
+          title: 'Name of a tutorial',
+          href: '#tutorial2',
+          tegs: ['tag1', 'tag2', 'tag3', 'tag4'],
+        },
+        {
+          title: "View all SDK's",
+          href: '#sdks',
+        },
+      ],
+    },
+  ],
+};
+
+export const DefaultMobile = Template.bind({});
+DefaultMobile.args = Default.args;
+DefaultMobile.parameters = {
+  viewport: {
+    defaultViewport: 'xs',
+  },
+};
+
+export const DefaultDark = Template.bind({});
+DefaultDark.args = Default.args;
+DefaultDark.parameters = {
+  themes: {
+    default: 'dark',
+  },
+};

--- a/libs/design-system/src/lib/Components/LinkCard3Column/index.tsx
+++ b/libs/design-system/src/lib/Components/LinkCard3Column/index.tsx
@@ -25,7 +25,7 @@ export type LinkCard3ColumnProps = {
 
 export function LinkCard3Column({ items }: LinkCard3ColumnProps) {
   return (
-    <div className="grid grid-cols-1 gap-x-4 rounded-lg bg-white pb-8 dark:bg-primary-dark-gray md:grid-cols-3 md:flex-row">
+    <div className="grid grid-cols-1 pb-8 bg-white rounded-lg gap-x-4 dark:bg-primary-dark-gray md:grid-cols-3 md:flex-row">
       {items.map((item, index) => (
         <div
           key={`${item.title}-header`}
@@ -38,7 +38,7 @@ export function LinkCard3Column({ items }: LinkCard3ColumnProps) {
             'grid-column-start-3': index === 2,
           })}
         >
-          <h5 className="text-h5 mb-2 flex items-center">
+          <h5 className="flex items-center mb-2 text-h5">
             {item.icon && <span className="mr-2">{item.icon}</span>}{' '}
             {item.title}
           </h5>
@@ -50,43 +50,42 @@ export function LinkCard3Column({ items }: LinkCard3ColumnProps) {
       {items.map((item, index) => (
         <div
           key={`${item.title}-content`}
-          className={clsx('px-6 md:row-start-2 md:pb-8', {
-            'row-start-2': index === 0,
-            'row-start-4': index === 1,
-            'row-start-6': index === 2,
-          })}
+          className={clsx(
+            'divide-y divide-primary-gray-100 px-6 md:row-start-2 md:pb-8',
+            {
+              'row-start-2': index === 0,
+              'row-start-4': index === 1,
+              'row-start-6': index === 2,
+            }
+          )}
         >
-          {item.links?.map((link, index) => (
-            <a
-              key={link.title}
-              className="link-card-3-column-link group flex flex-col rounded-lg px-4 hover:bg-primary-gray-200"
-              href={link.href}
-            >
-              <span
-                className={clsx('display-block py-4', {
-                  'border-t border-t-primary-gray-200 dark:border-t-primary-gray-300 dark:group-hover:border-t-primary-gray-200':
-                    index > 0,
-                })}
+          {item.links?.map((link) => (
+            <div key={link.title} className="divided-item-hover">
+              <a
+                className="flex flex-col px-4 rounded-lg link-card-3-column-link group hover:bg-primary-gray-50"
+                href={link.href}
               >
-                <span className="flex justify-between">
-                  <span className="group-hover:text-primary-blue">
-                    {link.title}
+                <span className="py-4 display-block">
+                  <span className="flex justify-between">
+                    <span className="group-hover:text-primary-blue">
+                      {link.title}
+                    </span>
+                    <span className="pt-1 dark:group-hover:text-black">
+                      {isLinkExternal(link.href) ? (
+                        <ExternalLinkIcon height="16" />
+                      ) : (
+                        <ChevronRight height="16" />
+                      )}
+                    </span>
                   </span>
-                  <span className="pt-1 dark:group-hover:text-black">
-                    {isLinkExternal(link.href) ? (
-                      <ExternalLinkIcon height="16" />
-                    ) : (
-                      <ChevronRight height="16" />
-                    )}
+                  <span>
+                    {link.tags?.map((tag) => (
+                      <Tag key={tag} name={tag} />
+                    ))}
                   </span>
                 </span>
-                <span>
-                  {link.tags?.map((tag) => (
-                    <Tag key={tag} name={tag} />
-                  ))}
-                </span>
-              </span>
-            </a>
+              </a>
+            </div>
           ))}
         </div>
       ))}

--- a/libs/design-system/src/lib/Components/LinkCard3Column/index.tsx
+++ b/libs/design-system/src/lib/Components/LinkCard3Column/index.tsx
@@ -1,0 +1,95 @@
+import clsx from 'clsx';
+import { ReactComponent as ChevronRight } from '../../../../images/arrows/chevron-right.svg';
+import { ReactComponent as ExternalLinkIcon } from '../../../../images/content/external-link.svg';
+import { isLinkExternal } from '../Link/isLinkExternal';
+import Tag from '../Tag';
+
+export type LinkCard3ColumnItemProps = {
+  description: string;
+  icon?: React.ReactNode;
+  title: string;
+  links: Array<{
+    href: string;
+    title: string;
+    tags?: string[];
+  }>;
+};
+
+export type LinkCard3ColumnProps = {
+  items: [
+    LinkCard3ColumnItemProps,
+    LinkCard3ColumnItemProps,
+    LinkCard3ColumnItemProps
+  ];
+};
+
+export function LinkCard3Column({ items }: LinkCard3ColumnProps) {
+  return (
+    <div className="grid grid-cols-1 gap-x-4 rounded-lg bg-white pb-8 dark:bg-primary-dark-gray md:grid-cols-3 md:flex-row">
+      {items.map((item, index) => (
+        <div
+          key={`${item.title}-header`}
+          className={clsx('px-10 pt-16 md:row-start-1', {
+            'row-start-1': index === 0,
+            'row-start-3': index === 1,
+            'row-start-5': index === 2,
+            'grid-column-start-1': index === 0,
+            'grid-column-start-2': index === 1,
+            'grid-column-start-3': index === 2,
+          })}
+        >
+          <h5 className="text-h5 mb-2 flex items-center">
+            {item.icon && <span className="mr-2">{item.icon}</span>}{' '}
+            {item.title}
+          </h5>
+          <p className="text-primary-gray-300 dark:text-primary-gray-50">
+            {item.description}
+          </p>
+        </div>
+      ))}
+      {items.map((item, index) => (
+        <div
+          key={`${item.title}-content`}
+          className={clsx('px-6 md:row-start-2 md:pb-8', {
+            'row-start-2': index === 0,
+            'row-start-4': index === 1,
+            'row-start-6': index === 2,
+          })}
+        >
+          {item.links?.map((link, index) => (
+            <a
+              key={link.title}
+              className="link-card-3-column-link group flex flex-col rounded-lg px-4 hover:bg-primary-gray-200"
+              href={link.href}
+            >
+              <span
+                className={clsx('display-block py-4', {
+                  'border-t border-t-primary-gray-200 dark:border-t-primary-gray-300 dark:group-hover:border-t-primary-gray-200':
+                    index > 0,
+                })}
+              >
+                <span className="flex justify-between">
+                  <span className="group-hover:text-primary-blue">
+                    {link.title}
+                  </span>
+                  <span className="pt-1 dark:group-hover:text-black">
+                    {isLinkExternal(link.href) ? (
+                      <ExternalLinkIcon height="16" />
+                    ) : (
+                      <ChevronRight height="16" />
+                    )}
+                  </span>
+                </span>
+                <span>
+                  {link.tags?.map((tag) => (
+                    <Tag key={tag} name={tag} />
+                  ))}
+                </span>
+              </span>
+            </a>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/libs/design-system/styles/main.css
+++ b/libs/design-system/styles/main.css
@@ -7,3 +7,9 @@
 @import './colors';
 @import './mdx';
 @import './reach-ui.css';
+
+/* Add .divided-item-hover to .divide-y children to hide borders on hover */
+.divided-item-hover:hover,
+.divided-item-hover:hover + .divided-item-hover {
+  @apply !border-transparent;
+}


### PR DESCRIPTION
The original PR for this got merged into a feature branch instead of `main`, so I've rebased and am putting up another PR.

It looks like many of the styles from [main.css](https://github.com/onflow/next-docs-v1/compare/joe/link-card-3-column?expand=1#diff-3bb88258c233f8a1dbdba6fff848f5366fc7f30b638320e4a5bf759930759700) have since been removed. Is this still the correct place to add the `.divided-item-hover` class? Or should that go elsewhere now?