### PR TITLE
Improve error UI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, typecheck]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,6 +5,7 @@ import type {
 } from "@remix-run/node"
 import { json } from "@remix-run/node"
 import {
+  Link,
   Links,
   LiveReload,
   Meta,
@@ -12,6 +13,7 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
+  useLocation,
 } from "@remix-run/react"
 import clsx from "clsx"
 import {
@@ -25,6 +27,8 @@ import styles from "./main.css"
 import { bodyClasses } from "./styles/sharedClasses"
 import { getThemeSession } from "./theme.server"
 import { Footer } from "./ui/design-system/src"
+import { ButtonLink } from "./ui/design-system/src/lib/Components/Button"
+import { ErrorPage } from "./ui/design-system/src/lib/Components/ErrorPage"
 
 export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }]
@@ -79,5 +83,32 @@ export default function AppWithProviders() {
     <ThemeProvider specifiedTheme={data.theme}>
       <App />
     </ThemeProvider>
+  )
+}
+
+export function ErrorBoundary({ error }: { error: Error }) {
+  console.error(error)
+  const location = useLocation()
+  return (
+    <html className="flex min-h-full bg-red-300">
+      <head>
+        <title>An unexpected error occured</title>
+        <Meta />
+        <Links />
+      </head>
+      <body className="flex flex-1 align-middle">
+        <ErrorPage
+          title={"500 – An unexpected error occured"}
+          subtitle={`"${location.pathname}" is currently not working`}
+          actions={
+            <Link className="underline" to="/">
+              Go home
+            </Link>
+          }
+        />
+        {/* add the UI you want your users to see */}
+        <Scripts />
+      </body>
+    </html>
   )
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -27,7 +27,6 @@ import styles from "./main.css"
 import { bodyClasses } from "./styles/sharedClasses"
 import { getThemeSession } from "./theme.server"
 import { Footer } from "./ui/design-system/src"
-import { ButtonLink } from "./ui/design-system/src/lib/Components/Button"
 import { ErrorPage } from "./ui/design-system/src/lib/Components/ErrorPage"
 
 export const links: LinksFunction = () => {

--- a/app/routes/$repo.$.tsx
+++ b/app/routes/$repo.$.tsx
@@ -11,7 +11,17 @@ import { ErrorPage } from "~/ui/design-system/src/lib/Components/ErrorPage"
 // might add this repo mapping to json resource endpoint
 // TODO: Allow specifying a specific branch, ideally dynamically (from publisher-land)
 // ... but we can hardcode  master / main for MVP
-const repos = ["cadence", "fcl-js"]
+const repos = [
+  "flow",
+  "cadence",
+  "flow-cli",
+  "flow-js-testing",
+  "flow-go-sdk",
+  "fcl-js",
+  "flow-emulator",
+  "flow-cadut",
+  "mock-developer-doc",
+]
 
 const validRepo = (repo: string | undefined) => {
   return repos.includes(repo!)

--- a/app/routes/$repo.$.tsx
+++ b/app/routes/$repo.$.tsx
@@ -1,8 +1,9 @@
 // import { InternalSidebar } from "@flow-docs/ui";
 import type { LoaderFunction, MetaFunction } from "@remix-run/node"
-import { useLoaderData, useCatch } from "@remix-run/react"
+import { useLoaderData, useCatch, Link, useLocation } from "@remix-run/react"
 import { json } from "@remix-run/node"
 import { getMdxPage, useMdxComponent } from "~/cms/utils/mdx"
+import { ErrorPage } from "~/ui/design-system/src/lib/Components/ErrorPage"
 
 // import { TEMP_SIDEBAR_CONFIG } from "@flow-docs/ui";
 
@@ -24,6 +25,9 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   // Here we forward the request if the first URL segemnt does
   // not match a repo we know about ...
 
+  if (!validRepo(params["repo"])) {
+    throw json({ status: "noRepo" }, { status: 404 })
+  }
   // TODO: make this redirect to appropriate section for repo
   // If no approapriate section, then fall through and try to get content
   // for the repo ... otherwise return Response and handle down the chain?
@@ -43,11 +47,11 @@ export const loader: LoaderFunction = async ({ params, request }) => {
       { request, forceFresh: process.env.FORCE_REFRESH === "true" }
     )
   } catch (e) {
-    throw json({ noPage: true }, { status: 500 })
+    throw json({ status: "noPage" }, { status: 500 })
   }
 
   if (!page) {
-    throw json({ noPage: true }, { status: 404 })
+    throw json({ status: "noPage" }, { status: 404 })
   }
 
   return {
@@ -70,8 +74,32 @@ export default function () {
 export function CatchBoundary() {
   const caught = useCatch()
   console.error("CatchBoundary", caught)
-  if (caught.data.noPage) {
-    return <div>No Page</div>
+  if (caught.data.status === "noPage") {
+    return (
+      <ErrorPage
+        title={"404 – Page not found"}
+        subtitle={`there is no page at "${location.pathname}"`}
+        actions={
+          <Link className="underline" to="/">
+            Go home
+          </Link>
+        }
+      />
+    )
   }
+  if (caught.data.status === "noRepo") {
+    return (
+      <ErrorPage
+        title={"404 – Repo not found"}
+        subtitle={`This repo is not available or does not exist`}
+        actions={
+          <Link className="underline" to="/">
+            Go home
+          </Link>
+        }
+      />
+    )
+  }
+
   throw new Error(`Unhandled error: ${caught.status}`)
 }

--- a/app/routes/$repo.$.tsx
+++ b/app/routes/$repo.$.tsx
@@ -74,6 +74,7 @@ export default function () {
 export function CatchBoundary() {
   const caught = useCatch()
   console.error("CatchBoundary", caught)
+  const location = useLocation()
   if (caught.data.status === "noPage") {
     return (
       <ErrorPage

--- a/app/ui/design-system/src/lib/Components/ErrorPage/index.tsx
+++ b/app/ui/design-system/src/lib/Components/ErrorPage/index.tsx
@@ -7,8 +7,8 @@ export const ErrorPage = (props: {
   actions: ReactNode
 }) => {
   return (
-    <div className="flex flex-1 flex-col ">
-      <div className="mx-auto flex max-w-3xl flex-col overflow-auto py-6 px-4">
+    <div className="flex flex-1 flex-col p-12">
+      <div className="mx-auto flex max-w-3xl flex-col overflow-auto ">
         <div className="grid gap-2">
           <div className="font-extrabold">{props.title}</div>
           <div>{props.subtitle}</div>

--- a/app/ui/design-system/src/lib/Components/ErrorPage/index.tsx
+++ b/app/ui/design-system/src/lib/Components/ErrorPage/index.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from "react"
+
+export const ErrorPage = (props: {
+  title: string
+  subtitle: string
+  /** e.g. a link to go back to a working state */
+  actions: ReactNode
+}) => {
+  return (
+    <div className="flex flex-1 flex-col ">
+      <div className="mx-auto flex max-w-3xl flex-col overflow-auto py-6 px-4">
+        <div className="grid gap-2">
+          <div className="font-extrabold">{props.title}</div>
+          <div>{props.subtitle}</div>
+          <div>{props.actions}</div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- Add basic root level error page
- Fix access around repos that aren't available

Fixes #119 
Fixes #116 

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/921605/173433341-3fbee5cc-10dd-4d6d-838d-3dcbebfba5cf.png">


previously this looked like this

<img width="1807" alt="image" src="https://user-images.githubusercontent.com/921605/173433816-5c5a2424-43ab-4693-9ac4-f80674db2e18.png">


https://flow-docs.fly.dev/mock-developer-doc/releasing
