### PR TITLE
Add main image to landing page header

### DIFF
--- a/app/ui/design-system/src/lib/Components/LandingHeader/LandingHeader.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/LandingHeader/LandingHeader.stories.tsx
@@ -30,7 +30,6 @@ Community.args = {
   callout: "Featured callout here two lines",
   description:
     "Lorem ipsum dolor sit amet proin gravida lorem ipsum dolor sit.",
-  gradient: "community",
   title: "Community",
 }
 
@@ -38,7 +37,6 @@ export const GettingStarted = Template.bind({})
 GettingStarted.args = {
   ...Community.args,
   title: "Getting Started",
-  gradient: "getting-started",
   description:
     "Everything you need to start building on Flow verything you need to start building on Flow ever.",
 }
@@ -53,12 +51,10 @@ export const Concepts = Template.bind({})
 Concepts.args = {
   ...Community.args,
   title: "Concepts",
-  gradient: "concepts",
 }
 
 export const Tools = Template.bind({})
 Tools.args = {
   ...Community.args,
   title: "Tools",
-  gradient: "tools",
 }

--- a/app/ui/design-system/src/lib/Components/LandingHeader/index.tsx
+++ b/app/ui/design-system/src/lib/Components/LandingHeader/index.tsx
@@ -2,12 +2,14 @@ import { ReactComponent as DiscordIcon } from "../../../../images/social/discord
 import { ReactComponent as GithubIcon } from "../../../../images/social/github"
 import { DISCORD_URL, GITHUB_URL } from "../../constants"
 import { ButtonLink } from "../Button"
+import LandingImage from "../../../../images/misc/landing-home.png"
 
 export type LandingHeaderProps = {
   buttonText: string
   buttonUrl: string
   callout: string
   description: string
+  imageSrc?: string
   title: string
 }
 
@@ -39,6 +41,7 @@ export function LandingHeader({
   buttonUrl,
   callout,
   description,
+  imageSrc = LandingImage,
   title,
 }: LandingHeaderProps) {
   return (
@@ -58,8 +61,11 @@ export function LandingHeader({
             {buttonText}
           </ButtonLink>
         </div>
-        <LandingHeaderLinks />
+        <div className="hidden rounded-r-lg border bg-white px-10 py-6 dark:bg-white/40 md:block md:block md:basis-1/2 md:px-20 md:py-12">
+          <img src={imageSrc} alt={title} />
+        </div>
       </div>
+      <LandingHeaderLinks />
     </div>
   )
 }


### PR DESCRIPTION
Adds a main image to the landing page header. Currently this defaults to the same image used on the homepage:

<img width="979" alt="Screen Shot 2022-06-17 at 2 49 07 PM" src="https://user-images.githubusercontent.com/393220/174383055-67aaa16f-109e-4d6d-867f-bce9a666f08a.png">

It collapses on mobile:
<img width="587" alt="Screen Shot 2022-06-17 at 2 49 21 PM" src="https://user-images.githubusercontent.com/393220/174383574-3a2dd5a7-39ae-4f16-b6ce-dc674cae08fa.png">

---

#194 