### PR TITLE
Social links should all be same width

### DIFF
--- a/app/ui/design-system/src/lib/Components/SocialLinksSignup/index.tsx
+++ b/app/ui/design-system/src/lib/Components/SocialLinksSignup/index.tsx
@@ -59,7 +59,7 @@ const SocialLinksSignup = () => {
     >
       <div className="container">
         <div
-          className="grid grid-flow-col grid-rows-4 rounded-lg px-4 md:grid-rows-2 md:px-0"
+          className="grid grid-cols-1 rounded-lg px-4 md:grid-cols-2 md:px-0"
           style={{ background: "rgba(213, 221, 233, 0.3)" }}
         >
           <SocialLink


### PR DESCRIPTION
Fixes social links grid so the columns are all the same width.

Before:
<img width="938" alt="Screen Shot 2022-06-17 at 3 01 45 PM" src="https://user-images.githubusercontent.com/393220/174386836-1510642e-f929-42ed-9d49-875e71256311.png">


After:

<img width="942" alt="Screen Shot 2022-06-17 at 3 01 57 PM" src="https://user-images.githubusercontent.com/393220/174386825-e164d1a8-2bf5-49c7-b98e-049ed2e5c9b0.png">


---

#194 