### PR TITLE
Recent articles uses a Carousel when necessary

### DIFF
--- a/app/routes/builders/index.tsx
+++ b/app/routes/builders/index.tsx
@@ -262,21 +262,33 @@ const recentToolItems: [ToolCardProps, ToolCardProps, ToolCardProps] = [
     link: "https://docs.flowser.dev/",
     stars: 28,
     iconSrc: "https://docs.flowser.dev/img/logo.svg",
-    description: `Flowser lets you inspect the current state of any flow blockchain network (emulator, testnet, mainnet,..) and 
+    description: `Flowser lets you inspect the current state of any flow blockchain network (emulator, testnet, mainnet,..) and
       it also manages the Flow emulator"`,
   },
 ]
 
-const recentArticleItems: FeaturedArticleCardProps = {
-  heading: "Introduction to Flow blockchain",
-  tags: ["protocol", "network"],
-  description: `When Dapper Labs built Crypto Kitties we learned a lot. 
-    Most importantly, we realized that the technology at the time was not ready for this kind of application. 
-    Being the visionaries we are, we set to build a better tech for what we plan to do. 
+const recentArticleItems: FeaturedArticleCardProps[] = [
+  {
+    heading: "Introduction to Flow blockchain",
+    tags: ["protocol", "network"],
+    description: `When Dapper Labs built Crypto Kitties we learned a lot.
+    Most importantly, we realized that the technology at the time was not ready for this kind of application.
+    Being the visionaries we are, we set to build a better tech for what we plan to do.
     We set to build what is now Flow blockchain.`,
-  link: "https://jan-bernatik.medium.com/introduction-to-flow-blockchain-7532977c8af8",
-  ctaText: "View Article",
-}
+    link: "https://jan-bernatik.medium.com/introduction-to-flow-blockchain-7532977c8af8",
+    ctaText: "View Article",
+  },
+  {
+    heading: "Introduction to Flow blockchain",
+    tags: ["protocol", "network"],
+    description: `When Dapper Labs built Crypto Kitties we learned a lot.
+    Most importantly, we realized that the technology at the time was not ready for this kind of application.
+    Being the visionaries we are, we set to build a better tech for what we plan to do.
+    We set to build what is now Flow blockchain.`,
+    link: "https://jan-bernatik.medium.com/introduction-to-flow-blockchain-7532977c8af8",
+    ctaText: "View Article",
+  },
+]
 
 const contentNavigationItems: [
   ContentNavigationProps,

--- a/app/ui/design-system/src/lib/Components/FeaturedArticleCard/index.tsx
+++ b/app/ui/design-system/src/lib/Components/FeaturedArticleCard/index.tsx
@@ -1,15 +1,18 @@
+import clsx from "clsx"
 import { ButtonLink } from "../Button"
 import Tag from "../Tag"
 
 export type FeaturedArticleCardProps = {
+  bg?: string
   heading: string
-  tags: string[]
+  tags?: string[]
   link: string
-  description: string
-  ctaText: string
+  description?: string
+  ctaText?: string
 }
 
 const FeaturedArticleCard = ({
+  bg = "bg-white dark:bg-primary-gray-dark",
   heading,
   tags,
   link,
@@ -17,16 +20,20 @@ const FeaturedArticleCard = ({
   ctaText,
 }: FeaturedArticleCardProps) => {
   return (
-    <div className="rounded-lg bg-white px-8 py-12 dark:bg-primary-gray-dark md:py-[122px] md:px-[80px]">
-      {tags.map((tag) => (
+    <div
+      className={clsx(bg, "rounded-lg px-8 py-12 md:py-[122px] md:px-[80px]")}
+    >
+      {tags?.map((tag) => (
         <Tag name={tag} key={tag} />
       ))}
       <div className="text-h2 my-2">{heading}</div>
-      <p className="mb-14 text-primary-gray-300 dark:text-primary-gray-200">
-        {description}
-      </p>
+      {description && (
+        <p className="mb-14 text-primary-gray-300 dark:text-primary-gray-200">
+          {description}
+        </p>
+      )}
       <ButtonLink href={link} className="px-6 py-4">
-        {ctaText}
+        {ctaText || heading}
       </ButtonLink>
     </div>
   )

--- a/app/ui/design-system/src/lib/Pages/GettingStartedPage/GettingStartedPage.stories.tsx
+++ b/app/ui/design-system/src/lib/Pages/GettingStartedPage/GettingStartedPage.stories.tsx
@@ -285,14 +285,24 @@ const gettingStartedPageData = {
       lastRelease: "207",
     },
   ],
-  recentArticleItems: {
-    heading: "This is a featured article with two rows title",
-    tags: ["Tag"],
-    description:
-      "Everything you need to start building on,  Flow verything you need to start building on start building on start building on",
-    link: "/article",
-    ctaText: "Click me!",
-  },
+  recentArticleItems: [
+    {
+      heading: "This is a featured article with two rows title",
+      tags: ["Tag"],
+      description:
+        "Everything you need to start building on,  Flow verything you need to start building on start building on start building on",
+      link: "/article",
+      ctaText: "Click me!",
+    },
+    {
+      heading: "This is a featured article with two rows title",
+      tags: ["Tag"],
+      description:
+        "Everything you need to start building on,  Flow verything you need to start building on start building on start building on",
+      link: "/article",
+      ctaText: "Click me!",
+    },
+  ],
   recentToolItems: [
     {
       title: "Flow Port",

--- a/app/ui/design-system/src/lib/Pages/GettingStartedPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/GettingStartedPage/index.tsx
@@ -1,5 +1,6 @@
 import { SocialLinksSignup } from "../../Components"
 import { ButtonLink } from "../../Components/Button"
+import { Carousel } from "../../Components/Carousel"
 import {
   ContentNavigation,
   ContentNavigationProps,
@@ -38,7 +39,7 @@ export interface GettingStartedPageProps {
     SDKCardProps,
     SDKCardProps
   ]
-  recentArticleItems: FeaturedArticleCardProps
+  recentArticleItems: FeaturedArticleCardProps[]
   recentToolItems: [ToolCardProps, ToolCardProps, ToolCardProps]
   contentNavigationItems: [
     ContentNavigationProps,
@@ -104,13 +105,11 @@ export function GettingStartedPage({
               </ButtonLink>
             </div>
             <div className="hidden md:block">
-              <FeaturedArticleCard
-                heading={recentArticleItems.heading}
-                tags={recentArticleItems.tags}
-                description={recentArticleItems.description}
-                link={recentArticleItems.link}
-                ctaText={recentArticleItems.ctaText}
-              />
+              <Carousel breakpoint="none" carouselItemWidth="w-full">
+                {recentArticleItems.map((recentArticleItem, index) => (
+                  <FeaturedArticleCard key={index} {...recentArticleItem} />
+                ))}
+              </Carousel>
             </div>
             <div className="flex grow flex-col justify-between gap-4">
               {recentToolItems.map((toolProps, i) => (

--- a/app/ui/design-system/src/lib/Pages/GettingStartedPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/GettingStartedPage/index.tsx
@@ -107,7 +107,11 @@ export function GettingStartedPage({
             <div className="hidden md:block">
               <Carousel breakpoint="none" carouselItemWidth="w-full">
                 {recentArticleItems.map((recentArticleItem, index) => (
-                  <FeaturedArticleCard key={index} {...recentArticleItem} />
+                  <FeaturedArticleCard
+                    bg="page-bg-gradient-getting-started bg-bottom border-primary-gray-100 border dark:border-primary-gray-400"
+                    key={index}
+                    {...recentArticleItem}
+                  />
                 ))}
               </Carousel>
             </div>


### PR DESCRIPTION
The "Recent Articles" section on the getting started page should take an array of items, and use a carousel when more than one item is given.

---

#194 