### PR TITLE
Concepts tab uses tutorial cards

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -13,6 +13,7 @@ import { ToolCardProps } from "~/ui/design-system/src/lib/Components/ToolCard"
 import { Default as DefaultToolAndConcepts } from "~/ui/design-system/src/lib/Components/ToolsAndConcepts/ToolsAndConcepts.stories"
 import { UpcomingEventsProps } from "~/ui/design-system/src/lib/Components/UpcomingEvents"
 import { Default as DefaultUpcomingEvents } from "~/ui/design-system/src/lib/Components/UpcomingEvents/UpcomingEvents.stories"
+import { TutorialCardProps } from "../ui/design-system/src/lib/Components/TutorialCard"
 
 export const startProjectItems: LinkCard2ColumnProps = {
   buttonText: "Get started",
@@ -119,7 +120,7 @@ type DynamicHomePageProps = Pick<
 export const loader: LoaderFunction = async () => {
   const flips = await fetchFlips()
   const tools = DefaultToolAndConcepts?.args?.tools as ToolCardProps[]
-  const concepts = DefaultToolAndConcepts.args?.concepts as ToolCardProps[]
+  const concepts = DefaultToolAndConcepts.args?.concepts as TutorialCardProps[]
   const upcomingEvents = DefaultUpcomingEvents?.args as UpcomingEventsProps
   const data: DynamicHomePageProps = { flips, tools, concepts, upcomingEvents }
   return data

--- a/app/ui/design-system/src/lib/Components/ToolsAndConcepts/ToolsAndConcepts.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ToolsAndConcepts/ToolsAndConcepts.stories.tsx
@@ -7,6 +7,17 @@ export default {
   title: "Components/ToolsAndConcepts",
 } as Meta
 
+const tutorialCard = {
+  heading: "This is a title with a header in a two line sentence",
+  tags: ["Tool"],
+  description: "An online contest that lorem ipsum ipsums ipsum",
+  lastUpdated: "23/3/2022",
+  level: "Beginners",
+  imageUri:
+    "https://assets.website-files.com/5f6294c0c7a8cdf432b1c827/5f6294c0c7a8cda922b1c968_Flow%2520Wide%2520Design-p-3200.png",
+  link: "/tutorials",
+}
+
 const Template: Story<ToolsAndConceptsProps> = (args) => {
   return (
     <PageBackground className="bg-primary-gray-50 py-6 dark:bg-black">
@@ -29,7 +40,7 @@ const tools = Array(6).fill({
 
 const DefaultArgs: ToolsAndConceptsProps = {
   tools,
-  concepts: tools,
+  concepts: Array(10).fill(tutorialCard),
 }
 export const Default = Template.bind({})
 Default.args = DefaultArgs

--- a/app/ui/design-system/src/lib/Components/ToolsAndConcepts/index.tsx
+++ b/app/ui/design-system/src/lib/Components/ToolsAndConcepts/index.tsx
@@ -1,29 +1,32 @@
+import { useState } from "react"
 import { TabMenu } from ".."
 import { ButtonLink } from "../Button"
 import { ToolCard, ToolCardProps } from "../ToolCard"
+import { TutorialCardProps } from "../TutorialCard"
+import { PaginatedTutorialCardList } from "../TutorialCard/PaginatedTutorialCardList"
 
 export type ToolsAndConceptsProps = {
   tools: ToolCardProps[]
   bottomButtons?: boolean
   headerButtontext?: string
-  concepts?: ToolCardProps[] // Not sure what this looks like yet.
+  concepts?: TutorialCardProps[] // Not sure what this looks like yet.
 }
 
 const ToolsAndConcepts = ({
   tools,
-  concepts,
+  concepts = [],
   headerButtontext = "",
   bottomButtons = true,
 }: ToolsAndConceptsProps) => {
-  const getHeading = () => {
-    return concepts && concepts.length > 0 ? "Tools and Concepts" : "Tools"
-  }
+  const [selectedTabIndex, setSelectedTabIndex] = useState(0)
 
   return (
     <div className="container">
       <div className="flex items-center justify-between">
         <div>
-          <div className="text-h2 mb-2">{getHeading()}</div>
+          <div className="text-h2 mb-2">
+            {concepts.length > 0 ? "Tools and Concepts" : "Tools"}
+          </div>
           <p>
             Core concepts and tools you’ll need to get started building on Flow
           </p>
@@ -36,14 +39,24 @@ const ToolsAndConcepts = ({
           </div>
         )}
       </div>
-      {concepts && concepts.length > 0 && (
-        <TabMenu tabs={["Tools", "Concepts"]} onTabChange={() => null} />
+      {concepts.length > 0 && (
+        <TabMenu
+          tabs={["Tools", "Concepts"]}
+          onTabChange={(index) => setSelectedTabIndex(index)}
+        />
       )}
-      <div className="mt-9 grid gap-4 md:grid-cols-2 md:gap-8">
-        {tools.map((tool: ToolCardProps, index) => (
-          <ToolCard {...tool} key={index} />
-        ))}
-      </div>
+      {selectedTabIndex === 0 && (
+        <div className="grid gap-4 pt-9 md:grid-cols-2 md:gap-8">
+          {tools.map((tool: ToolCardProps, index) => (
+            <ToolCard {...tool} key={index} />
+          ))}
+        </div>
+      )}
+      {selectedTabIndex === 1 && (
+        <div className="pt-9">
+          <PaginatedTutorialCardList tutorials={concepts} />
+        </div>
+      )}
       {!!bottomButtons && (
         <div className="mt-9 flex flex-col justify-between md:flex-row">
           <ButtonLink

--- a/app/ui/design-system/src/lib/Pages/HomePage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/HomePage/index.tsx
@@ -11,6 +11,7 @@ import { FlipsProps } from "../../Components/Flips"
 import { LinkCard2ColumnProps } from "../../Components/LinkCard2Column"
 import { LinkCard3ColumnItems } from "../../Components/LinkCard3Column"
 import { ToolCardProps } from "../../Components/ToolCard"
+import { TutorialCardProps } from "../../Components/TutorialCard"
 import { UpcomingEventsProps } from "../../Components/UpcomingEvents"
 import PageBackground from "../shared/PageBackground"
 import PageSection from "../shared/PageSection"
@@ -20,7 +21,7 @@ export type HomePageProps = {
   startProjectItems: LinkCard2ColumnProps
   flips: FlipsProps
   tools: ToolCardProps[]
-  concepts?: ToolCardProps[]
+  concepts?: TutorialCardProps[]
   threeColumnItems: LinkCard3ColumnItems
   upcomingEvents: UpcomingEventsProps
 }


### PR DESCRIPTION
Per #194, the "Concepts" tab of the "Tools and Concepts" section should be displayed using the tutorial card layout.