### PR TITLE
Adds background gradient to Recent Articles

### DIFF
--- a/app/ui/design-system/src/lib/Components/FeaturedArticleCard/index.tsx
+++ b/app/ui/design-system/src/lib/Components/FeaturedArticleCard/index.tsx
@@ -1,15 +1,18 @@
+import clsx from "clsx"
 import { ButtonLink } from "../Button"
 import Tag from "../Tag"
 
 export type FeaturedArticleCardProps = {
+  bg?: string
   heading: string
-  tags: string[]
+  tags?: string[]
   link: string
-  description: string
-  ctaText: string
+  description?: string
+  ctaText?: string
 }
 
 const FeaturedArticleCard = ({
+  bg = "bg-white dark:bg-primary-gray-dark",
   heading,
   tags,
   link,
@@ -17,16 +20,20 @@ const FeaturedArticleCard = ({
   ctaText,
 }: FeaturedArticleCardProps) => {
   return (
-    <div className="rounded-lg bg-white px-8 py-12 dark:bg-primary-gray-dark md:py-[122px] md:px-[80px]">
-      {tags.map((tag) => (
+    <div
+      className={clsx(bg, "rounded-lg px-8 py-12 md:py-[122px] md:px-[80px]")}
+    >
+      {tags?.map((tag) => (
         <Tag name={tag} key={tag} />
       ))}
       <div className="text-h2 my-2">{heading}</div>
-      <p className="mb-14 text-primary-gray-300 dark:text-primary-gray-200">
-        {description}
-      </p>
+      {description && (
+        <p className="mb-14 text-primary-gray-300 dark:text-primary-gray-200">
+          {description}
+        </p>
+      )}
       <ButtonLink href={link} className="px-6 py-4">
-        {ctaText}
+        {ctaText || heading}
       </ButtonLink>
     </div>
   )

--- a/app/ui/design-system/src/lib/Pages/GettingStartedPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/GettingStartedPage/index.tsx
@@ -107,7 +107,11 @@ export function GettingStartedPage({
             <div className="hidden md:block">
               <Carousel breakpoint="none" carouselItemWidth="w-full">
                 {recentArticleItems.map((recentArticleItem, index) => (
-                  <FeaturedArticleCard key={index} {...recentArticleItem} />
+                  <FeaturedArticleCard
+                    bg="page-bg-gradient-getting-started bg-bottom border-primary-gray-100 border dark:border-primary-gray-400"
+                    key={index}
+                    {...recentArticleItem}
+                  />
                 ))}
               </Carousel>
             </div>


### PR DESCRIPTION
Per #194, adds a background gradient to the "Recent Articles". I used the same gradient that the top of the page uses.

<img width="539" alt="Screen Shot 2022-06-17 at 5 30 30 PM" src="https://user-images.githubusercontent.com/393220/174404061-970452e3-75b8-4bf2-8db8-dbf9fa2b553c.png">

<img width="598" alt="Screen Shot 2022-06-17 at 5 31 57 PM" src="https://user-images.githubusercontent.com/393220/174404063-25061083-d94a-4055-be8a-9e7b0a996d34.png">

