### PR TITLE
Pull issues from multiple repos for good places to start issues

### DIFF
--- a/app/ui/design-system/src/lib/Components/Flips/index.tsx
+++ b/app/ui/design-system/src/lib/Components/Flips/index.tsx
@@ -42,13 +42,14 @@ export default function Flips({
         <div className="py-6">
           <FlipCellHeader />
           <div className="flex flex-col gap-4">
-            {(selectedTab === 0 ? openFlips : goodPlacesToStartFlips).map(
-              (flip, index) => (
+            {(selectedTab === 0 ? openFlips : goodPlacesToStartFlips)
+              .sort((a, b) => (a.numComments > b.numComments ? -1 : 1))
+              .slice(0, 5)
+              .map((flip, index) => (
                 <div key={index}>
                   <FlipCell {...flip} />
                 </div>
-              )
-            )}
+              ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
* Pulling from more repositories now in addition to onflow/flow, onflow/fcl-js, onflow/kitty-items, onflow/flow-go-sdk
* Sorting by number of comments, and displaying at max 5 issues (rendered in the component)

<img width="1319" alt="Screen Shot 2022-06-18 at 2 31 00 PM" src="https://user-images.githubusercontent.com/18616121/174451840-fed066cd-7f47-48d2-96a5-d6082288110d.png">
