### PR TITLE
"All content" section UI fixes

### DIFF
--- a/app/ui/design-system/src/lib/Components/TutorialCard/PaginatedTutorialCardList.tsx
+++ b/app/ui/design-system/src/lib/Components/TutorialCard/PaginatedTutorialCardList.tsx
@@ -14,6 +14,8 @@ export type PaginatedTutorialCardListProps = {
   pageSize?: number
 
   tutorials: TutorialCardProps[]
+
+  scrollOnPaginate: boolean
 }
 
 export const PaginatedTutorialCardList = ({
@@ -21,6 +23,7 @@ export const PaginatedTutorialCardList = ({
   listId,
   pageSize = 4,
   tutorials,
+  scrollOnPaginate = true,
 }: PaginatedTutorialCardListProps) => {
   const topRef = useRef<HTMLDivElement>()
   const [page, setPage] = useState(1)
@@ -40,7 +43,7 @@ export const PaginatedTutorialCardList = ({
   }, [listId])
 
   useLayoutEffect(() => {
-    if (resetScroll > 0) {
+    if (resetScroll > 0 && scrollOnPaginate) {
       // We don't want to scroll on the initial render.
       topRef.current?.scrollIntoView({ behavior: "smooth" })
     }

--- a/app/ui/design-system/src/lib/Components/TutorialCard/PaginatedTutorialCardList.tsx
+++ b/app/ui/design-system/src/lib/Components/TutorialCard/PaginatedTutorialCardList.tsx
@@ -47,7 +47,7 @@ export const PaginatedTutorialCardList = ({
       // We don't want to scroll on the initial render.
       topRef.current?.scrollIntoView({ behavior: "smooth" })
     }
-  }, [resetScroll])
+  }, [resetScroll, scrollOnPaginate])
 
   return (
     <div className={className}>

--- a/app/ui/design-system/src/lib/Components/TutorialCard/PaginatedTutorialCardList.tsx
+++ b/app/ui/design-system/src/lib/Components/TutorialCard/PaginatedTutorialCardList.tsx
@@ -15,7 +15,7 @@ export type PaginatedTutorialCardListProps = {
 
   tutorials: TutorialCardProps[]
 
-  scrollOnPaginate: boolean
+  scrollOnPaginate?: boolean
 }
 
 export const PaginatedTutorialCardList = ({

--- a/app/ui/design-system/src/lib/Pages/LearnPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/LearnPage/index.tsx
@@ -168,6 +168,8 @@ export function LearnPage({
             <PaginatedTutorialCardList
               listId={filters}
               tutorials={allTutorialsFiltered}
+              pageSize={8}
+              scrollOnPaginate={false}
             />
           </div>
         </PageSection>


### PR DESCRIPTION
# Description

Fix "All content" section UI by displaying more tutorial cards and disabling scrolling to list on pagination

![Screen Shot 2022-06-20 at 3 04 16 PM](https://user-images.githubusercontent.com/46465568/174677438-d8e9000b-49cd-481d-ad9a-0a87464adc6b.png)
