### PR TITLE
Add Google Analytics script

### DIFF
--- a/app/env.server.ts
+++ b/app/env.server.ts
@@ -9,6 +9,7 @@ function getEnv() {
     REDIS_CA: process.env.REDIS_CA,
     REFRESH_CACHE_SECRET: process.env.REFRESH_CACHE_SECRET,
     STATUSPAGE_API_KEY: process.env.STATUSPAGE_API_KEY,
+    GA_TRACKING_ID: process.env.GA_TRACKING_ID,
   }
 }
 

--- a/app/gtags.client.ts
+++ b/app/gtags.client.ts
@@ -1,0 +1,48 @@
+declare global {
+  interface Window {
+    gtag: (
+      option: string,
+      gaTrackingId: string,
+      options: Record<string, unknown>
+    ) => void
+  }
+}
+
+/**
+ * @example
+ * https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+ */
+export const pageview = (url: string, trackingId: string) => {
+  if (!window.gtag) {
+    console.warn(
+      "window.gtag is not defined. This could mean your google anylatics script has not loaded on the page yet."
+    )
+    return
+  }
+  window.gtag("config", trackingId, {
+    page_path: url,
+  })
+}
+
+/**
+ * @example
+ * https://developers.google.com/analytics/devguides/collection/gtagjs/events
+ */
+export const event = ({
+  action,
+  category,
+  label,
+  value,
+}: Record<string, string>) => {
+  if (!window.gtag) {
+    console.warn(
+      "window.gtag is not defined. This could mean your google anylatics script has not loaded on the page yet."
+    )
+    return
+  }
+  window.gtag("event", action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  })
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,7 +16,7 @@ import {
   useLocation,
 } from "@remix-run/react"
 import clsx from "clsx"
-import { useCallback } from "react"
+import { useCallback, useEffect } from "react"
 import {
   Theme,
   ThemeBody,
@@ -24,12 +24,14 @@ import {
   ThemeProvider,
   useTheme,
 } from "~/cms/utils/theme.provider"
+import { getRequiredServerEnvVar } from "./cms/helpers"
 import { navBarData } from "./component-data/NavigationBar"
 import styles from "./main.css"
 import { getThemeSession } from "./theme.server"
 import { Footer } from "./ui/design-system/src"
 import { ErrorPage } from "./ui/design-system/src/lib/Components/ErrorPage"
 import { NavigationBar } from "./ui/design-system/src/lib/Components/NavigationBar"
+import * as gtag from "./gtags.client"
 
 export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }]
@@ -43,23 +45,33 @@ export const meta: MetaFunction = () => ({
 
 export type LoaderData = {
   theme: Theme | null
+  gaTrackingId: string | undefined
 }
 
 export const loader: LoaderFunction = async ({ request }) => {
   const themeSession = await getThemeSession(request)
   return json<LoaderData>({
     theme: themeSession.getTheme(),
+    gaTrackingId: getRequiredServerEnvVar("GA_TRACKING_ID"),
   })
 }
 
 function App() {
   const data = useLoaderData<LoaderData>()
+
   const [theme, setTheme] = useTheme()
   const toggleTheme = useCallback(() => {
     setTheme((currentTheme) =>
       currentTheme === Theme.DARK ? Theme.LIGHT : Theme.DARK
     )
   }, [setTheme])
+
+  const location = useLocation()
+  useEffect(() => {
+    if (data.gaTrackingId?.length) {
+      gtag.pageview(location.pathname, data.gaTrackingId)
+    }
+  }, [location, data.gaTrackingId])
 
   return (
     <html
@@ -72,6 +84,29 @@ function App() {
         <ThemeHead ssrTheme={Boolean(data.theme)} />
       </head>
       <body className="root">
+        {!data.gaTrackingId ? null : (
+          <>
+            <script
+              async
+              src={`https://www.googletagmanager.com/gtag/js?id=${data.gaTrackingId}`}
+            />
+            <script
+              async
+              id="gtag-init"
+              dangerouslySetInnerHTML={{
+                __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${data.gaTrackingId}', {
+                  page_path: window.location.pathname,
+                });
+              `,
+              }}
+            />
+          </>
+        )}
+
         <ThemeBody ssrTheme={Boolean(data.theme)} />
         <NavigationBar
           menuItems={navBarData.menuItems}

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -1,0 +1,43 @@
+// This route is only for tracking events for Google Analytics. This page should not be discoverable by the navigation.
+import type { ActionFunction } from "@remix-run/node"
+import { json } from "@remix-run/node"
+import { Form } from "@remix-run/react"
+import type { SyntheticEvent } from "react"
+import * as gtag from "~/gtags.client"
+
+export const action: ActionFunction = () => {
+  return json({})
+}
+
+export default function Contact() {
+  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+    const target = e.target as typeof e.target & {
+      message: { value: string }
+    }
+
+    console.log(`event.target.message value is: '${target.message.value}'`)
+    console.log(`event object is:`, e)
+
+    gtag.event({
+      action: "submit_form",
+      category: "Contact",
+      label: target.message.value,
+    })
+  }
+
+  return (
+    <main>
+      <h1>This is the Contact page</h1>
+      <Form onSubmit={handleSubmit} replace={false} id="contact-form">
+        <label>
+          <span>Message:</span>
+          <textarea name="message" />
+        </label>
+        <button type="submit">submit</button>
+      </Form>
+
+      {/* Fun fact: if you want to use your button outside the form element you can as long as you associate the button with a form attribute targeting the id of the form */}
+      {/* <button type="submit" form="contact-form">submit</button> */}
+    </main>
+  )
+}

--- a/app/routes/load-flips.tsx
+++ b/app/routes/load-flips.tsx
@@ -1,3 +1,4 @@
+// This route is only for testing API functionalities. This page should not be discoverable by the navigation.
 import type { LoaderFunction } from "@remix-run/node"
 import { useLoaderData } from "@remix-run/react"
 import { fetchFlips } from "~/cms/utils/fetch-flips"

--- a/app/routes/poll-discourse.tsx
+++ b/app/routes/poll-discourse.tsx
@@ -1,3 +1,4 @@
+// This route is only for testing Discourse API functionalities. This page should not be discoverable by the navigation.
 import { useFetcher, useLoaderData } from "@remix-run/react"
 import { useEffect, useState } from "react"
 import {

--- a/app/routes/poll-network.tsx
+++ b/app/routes/poll-network.tsx
@@ -1,3 +1,4 @@
+// This route is only for testing network API functionalities. This page should not be discoverable by the navigation.
 import { useFetcher, useLoaderData } from "@remix-run/react"
 import { useEffect, useState } from "react"
 import { POLLING_INTERVAL_FIVE_SECONDS } from "~/cms/utils/constants"


### PR DESCRIPTION
Changes were based on the remix example here:
https://github.com/remix-run/remix/tree/2be33735d62ed43301c3b6ce9f0f8e9af8fa2454/examples/google-analytics

After this merge, there needs to be an entry in `.env` as such: 
```
# Google Analytics
GA_TRACKING_ID=...
```