### PR TITLE
Storybook enhancements

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -80,11 +80,12 @@ const withDarkMode = (Story, context) => {
   const isDarkModeSelected = globals.backgrounds?.value === "#000000"
   const isDarkMode = isDarkModeSelected || isDefaultDarkModeStory
 
-  return (
-    <div className={clsx("root", { dark: isDarkMode })}>
-      <Story {...context} />
-    </div>
-  )
+  useEffect(() => {
+    document.body.classList.add("root")
+    document.body.classList[isDarkMode ? "add" : "remove"]("dark")
+  })
+
+  return <Story {...context} />
 }
 
 export const decorators = [withDarkMode]

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import { useGlobals, useParameter } from "@storybook/addons"
+import { useGlobals, useParameter, useEffect } from "@storybook/addons"
 import clsx from "clsx"
 import "../app/main.css"
 import tailwindConfig from "../tailwind.config"
@@ -17,7 +17,7 @@ export const parameters = {
     values: [
       {
         name: "light",
-        value: "#ffffff",
+        value: "#f6f7f9",
       },
       {
         name: "dark",

--- a/app/ui/design-system/src/lib/Components/AnnouncementCard/AnnouncementCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/AnnouncementCard/AnnouncementCard.stories.tsx
@@ -5,14 +5,13 @@ import { endOfDay } from "date-fns"
 export default {
   component: AnnouncementCard,
   title: "Components/AnnouncementCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<AnnouncementCardProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <AnnouncementCard {...args} />
-    </div>
-  )
+  return <AnnouncementCard {...args} />
 }
 
 const args = {

--- a/app/ui/design-system/src/lib/Components/Attribution/Attribution.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/Attribution/Attribution.stories.tsx
@@ -4,13 +4,12 @@ import { Attribution, AttributionProps } from "./Attribution"
 export default {
   component: Attribution,
   title: "Components/Attribution",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
-const Template: Story<AttributionProps> = (args) => (
-  <div style={{ padding: "1rem" }}>
-    <Attribution {...args} />
-  </div>
-)
+const Template: Story<AttributionProps> = (args) => <Attribution {...args} />
 
 export const Default = Template.bind({})
 

--- a/app/ui/design-system/src/lib/Components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -4,6 +4,9 @@ import { Breadcrumbs, BreadcrumbsProps } from "."
 export default {
   component: Breadcrumbs,
   title: "Components/Breadcrumbs",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<BreadcrumbsProps> = (args) => <Breadcrumbs {...args} />

--- a/app/ui/design-system/src/lib/Components/Button/Button.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/Button/Button.stories.tsx
@@ -13,6 +13,9 @@ export default {
       control: { type: "select" },
     },
   },
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<ButtonProps> = (args) => {
@@ -20,9 +23,9 @@ const Template: Story<ButtonProps> = (args) => {
     <div
       style={{
         gap: "1rem",
-        padding: "1rem",
         display: "inline-flex",
         flexDirection: "column",
+        width: "15rem",
       }}
     >
       <Button variant="primary">Primary</Button>
@@ -41,11 +44,4 @@ const Template: Story<ButtonProps> = (args) => {
 export const Default = Template.bind({})
 Default.args = {
   children: "Button",
-}
-export const defaultDark = Template.bind({})
-defaultDark.args = Default.args
-defaultDark.parameters = {
-  backgrounds: {
-    default: "dark",
-  },
 }

--- a/app/ui/design-system/src/lib/Components/Callout/Callout.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/Callout/Callout.stories.tsx
@@ -4,6 +4,9 @@ import Callout, { CalloutProps } from "."
 export default {
   component: Callout,
   title: "Components/Callout",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<CalloutProps> = (args) => {

--- a/app/ui/design-system/src/lib/Components/ContentNavigation/ContentNavigation.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ContentNavigation/ContentNavigation.stories.tsx
@@ -18,6 +18,9 @@ export default {
       control: { type: "select" },
     },
   },
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<ContentNavigationProps> = (args) => (

--- a/app/ui/design-system/src/lib/Components/EventCard/EventCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/EventCard/EventCard.stories.tsx
@@ -4,14 +4,13 @@ import { EventCard, EventCardList, EventCardProps, EventCardListProps } from "."
 export default {
   component: EventCard,
   title: "Components/EventCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const TemplateSingle: Story<EventCardProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <EventCard {...args} />
-    </div>
-  )
+  return <EventCard {...args} />
 }
 
 export const Default = TemplateSingle.bind({})
@@ -29,11 +28,7 @@ Default.args = {
 }
 
 const TemplateList: Story<EventCardListProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <EventCardList {...args} />
-    </div>
-  )
+  return <EventCardList {...args} />
 }
 
 export const EventList = TemplateList.bind({})

--- a/app/ui/design-system/src/lib/Components/EventCardSmall/EventCardSmall.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/EventCardSmall/EventCardSmall.stories.tsx
@@ -4,14 +4,13 @@ import { EventCardSmall, EventCardSmallProps } from "."
 export default {
   component: EventCardSmall,
   title: "Components/EventCardSmall",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<EventCardSmallProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <EventCardSmall {...args} />
-    </div>
-  )
+  return <EventCardSmall {...args} />
 }
 
 export const Default = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/FAQ/FAQ.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/FAQ/FAQ.stories.tsx
@@ -6,11 +6,7 @@ export default {
   title: "Components/FAQ",
 } as Meta
 
-const Template: Story<FAQProps> = (args) => (
-  <div className="bg-primary-gray-50 p-4 dark:bg-black">
-    <FAQ {...args} />
-  </div>
-)
+const Template: Story<FAQProps> = (args) => <FAQ {...args} />
 
 const faqList = [
   {

--- a/app/ui/design-system/src/lib/Components/FeatureLinkBlock/FeatureLinkBlock.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/FeatureLinkBlock/FeatureLinkBlock.stories.tsx
@@ -5,14 +5,13 @@ import FclIconSrc from "../../../../images/tools/tool-fcl.svg"
 export default {
   component: FeatureLinkBlock,
   title: "Components/FeatureLinkBlock",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<FeatureLinkBlockProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <FeatureLinkBlock {...args} />
-    </div>
-  )
+  return <FeatureLinkBlock {...args} />
 }
 
 export const Default = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/FeaturedArticleCard/FeaturedArticleCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/FeaturedArticleCard/FeaturedArticleCard.stories.tsx
@@ -4,12 +4,13 @@ import FeaturedArticleCard, { FeaturedArticleCardProps } from "."
 export default {
   component: FeaturedArticleCard,
   title: "Components/FeaturedArticleCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<FeaturedArticleCardProps> = (args) => (
-  <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-    <FeaturedArticleCard {...args} />
-  </div>
+  <FeaturedArticleCard {...args} />
 )
 
 const args = {

--- a/app/ui/design-system/src/lib/Components/FeaturedArticleSlider/FeaturedArticleSlider.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/FeaturedArticleSlider/FeaturedArticleSlider.stories.tsx
@@ -4,14 +4,13 @@ import FeaturedArticleSlider, { FeaturedArticleSliderProps } from "."
 export default {
   component: FeaturedArticleSlider,
   title: "Components/FeaturedArticleSlider",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<FeaturedArticleSliderProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "30px" }}>
-      <FeaturedArticleSlider {...args} />
-    </div>
-  )
+  return <FeaturedArticleSlider {...args} />
 }
 const args = {
   articles: [

--- a/app/ui/design-system/src/lib/Components/Flips/Flips.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/Flips/Flips.stories.tsx
@@ -4,14 +4,13 @@ import { default as FlipCell, default as Flips, FlipsProps } from "."
 export default {
   component: FlipCell,
   title: "Components/Flips",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<FlipsProps> = (args) => {
-  return (
-    <div style={{ padding: "1rem" }}>
-      <Flips {...args} />
-    </div>
-  )
+  return <Flips {...args} />
 }
 
 export const Default = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/ForumCell/ForumCell.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ForumCell/ForumCell.stories.tsx
@@ -4,14 +4,13 @@ import ForumCell, { ForumCellProps } from "."
 export default {
   component: ForumCell,
   title: "Components/ForumCell",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<ForumCellProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <ForumCell {...args} />
-    </div>
-  )
+  return <ForumCell {...args} />
 }
 
 export const Default = Template.bind({})
@@ -42,6 +41,7 @@ const args = {
     },
   ],
   forumLink: "#test",
+  lastUpdatedDate: "2022-06-06",
 }
 
 Default.args = args

--- a/app/ui/design-system/src/lib/Components/Heading/Heading.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/Heading/Heading.stories.tsx
@@ -3,15 +3,18 @@ import { Heading, HeadingProps } from "."
 
 export default {
   component: Heading,
+  parameters: {
+    layout: "padded",
+  },
   title: "Components/Heading",
 } as Meta
 
 const Template: Story<HeadingProps> = (args) => {
   return (
-    <div style={{ padding: 40 }}>
+    <>
       <Heading {...args} />
       <p>Paragraph</p>
-    </div>
+    </>
   )
 }
 

--- a/app/ui/design-system/src/lib/Components/InternalLandingCard/InternalLandingCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalLandingCard/InternalLandingCard.stories.tsx
@@ -4,6 +4,9 @@ import { InternalLandingCard, InternalLandingCardProps } from "."
 export default {
   component: InternalLandingCard,
   title: "Components/InternalLandingCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<InternalLandingCardProps> = (args) => {

--- a/app/ui/design-system/src/lib/Components/InternalSidebarMenu/InternalSidebarMenu.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebarMenu/InternalSidebarMenu.stories.tsx
@@ -4,14 +4,13 @@ import { InternalSidebarMenu, InternalSidebarMenuProps } from "."
 export default {
   component: InternalSidebarMenu,
   title: "Components/InternalSidebarMenu",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<InternalSidebarMenuProps> = (args) => {
-  return (
-    <div style={{ padding: "1rem" }}>
-      <InternalSidebarMenu {...args} />
-    </div>
-  )
+  return <InternalSidebarMenu {...args} />
 }
 
 export const Default = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/Link/Link.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/Link/Link.stories.tsx
@@ -5,6 +5,9 @@ import { Link, LinkProps } from "."
 export default {
   component: Link,
   title: "Components/Link",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<LinkProps> = (args) => (

--- a/app/ui/design-system/src/lib/Components/LinkCard2Column/LinkCard2Column.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/LinkCard2Column/LinkCard2Column.stories.tsx
@@ -14,6 +14,9 @@ export default {
   component: LinkCard2Column,
   title: "Components/LinkCard2Column",
   excludeStories: ["svgToDataUri"],
+  parameters: {
+    layout: "centered",
+  },
 } as Meta
 
 const Template: Story<LinkCard2ColumnProps> = (args) => {

--- a/app/ui/design-system/src/lib/Components/LinkCard3Column/LinkCard3Column.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/LinkCard3Column/LinkCard3Column.stories.tsx
@@ -7,14 +7,13 @@ import { ReactComponent as UseCaseIcon } from "../../../../images/content/use-ca
 export default {
   component: LinkCard3Column,
   title: "Components/LinkCard3Column",
+  parameters: {
+    layout: "centered",
+  },
 } as Meta
 
 const Template: Story<LinkCard3ColumnProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <LinkCard3Column {...args} />
-    </div>
-  )
+  return <LinkCard3Column {...args} />
 }
 
 export const Default = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/NetworkCard/NetworkCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/NetworkCard/NetworkCard.stories.tsx
@@ -4,14 +4,13 @@ import NetworkCard, { NetworkCardProps } from "."
 export default {
   component: NetworkCard,
   title: "Components/NetworkCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<NetworkCardProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <NetworkCard {...args} />
-    </div>
-  )
+  return <NetworkCard {...args} />
 }
 
 const args = {

--- a/app/ui/design-system/src/lib/Components/NetworkDetailsCard/NetworkDetailsCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/NetworkDetailsCard/NetworkDetailsCard.stories.tsx
@@ -4,14 +4,13 @@ import NetworkDetailsCard, { NetworkDetailsCardProps } from "."
 export default {
   component: NetworkDetailsCard,
   title: "Components/NetworkDetailsCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<NetworkDetailsCardProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <NetworkDetailsCard {...args} />
-    </div>
-  )
+  return <NetworkDetailsCard {...args} />
 }
 const args = {
   status: "Healthy",

--- a/app/ui/design-system/src/lib/Components/NetworkDiscordCard/NetworkDiscordCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/NetworkDiscordCard/NetworkDiscordCard.stories.tsx
@@ -5,14 +5,13 @@ import { endOfDay } from "date-fns"
 export default {
   component: NetworkDiscordCard,
   title: "Components/NetworkDiscordCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<NetworkDiscordCardProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <NetworkDiscordCard {...args} />
-    </div>
-  )
+  return <NetworkDiscordCard {...args} />
 }
 
 export const Default = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/Pagination/Pagination.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/Pagination/Pagination.stories.tsx
@@ -4,13 +4,12 @@ import Pagination, { PaginationProps } from "."
 export default {
   component: Pagination,
   title: "Components/Pagination",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
-const Template: Story<PaginationProps> = (args) => (
-  <div style={{ padding: "1em" }}>
-    <Pagination {...args} />
-  </div>
-)
+const Template: Story<PaginationProps> = (args) => <Pagination {...args} />
 
 export const Default = Template.bind({})
 Default.args = {

--- a/app/ui/design-system/src/lib/Components/ProjectCard/ProjectCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ProjectCard/ProjectCard.stories.tsx
@@ -4,13 +4,12 @@ import ProjectCard, { ProjectCardProps } from "."
 export default {
   component: ProjectCard,
   title: "Components/ProjectCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
-const Template: Story<ProjectCardProps> = (args) => (
-  <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-    <ProjectCard {...args} />
-  </div>
-)
+const Template: Story<ProjectCardProps> = (args) => <ProjectCard {...args} />
 
 const args = {
   projectImage:

--- a/app/ui/design-system/src/lib/Components/ProjectCards/ProjectCards.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ProjectCards/ProjectCards.stories.tsx
@@ -1,19 +1,17 @@
 import { Meta, Story } from "@storybook/react"
 import ProjectCards, { ProjectCardsProps } from "."
-import PageBackground from "../../Pages/shared/PageBackground"
 import { ProjectCardProps } from "../ProjectCard"
 import { Default as DefaultProjectCard } from "../ProjectCard/ProjectCard.stories"
 
 export default {
   component: ProjectCards,
   title: "Components/ProjectCards",
+  parameters: {
+    layout: "centered",
+  },
 } as Meta
 
-const Template: Story<ProjectCardsProps> = (args) => (
-  <PageBackground className="py-4">
-    <ProjectCards {...args} />
-  </PageBackground>
-)
+const Template: Story<ProjectCardsProps> = (args) => <ProjectCards {...args} />
 
 const projectCardArgs = DefaultProjectCard.args as ProjectCardProps
 export const Default = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/RoundImage/RoundImage.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/RoundImage/RoundImage.stories.tsx
@@ -4,6 +4,9 @@ import RoundImage, { RoundImageProps } from "."
 export default {
   component: RoundImage,
   title: "Components/RoundImage",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<RoundImageProps> = (args) => {

--- a/app/ui/design-system/src/lib/Components/SDKCard/SDKCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/SDKCard/SDKCard.stories.tsx
@@ -4,14 +4,13 @@ import { SDKCard, SDKCardProps } from "."
 export default {
   component: SDKCard,
   title: "Components/SDKCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<SDKCardProps> = (args) => {
-  return (
-    <div className="bg-gray-100 p-4 dark:bg-black">
-      <SDKCard {...args} />
-    </div>
-  )
+  return <SDKCard {...args} />
 }
 
 export const Default = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/SDKCards/SDKCards.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/SDKCards/SDKCards.stories.tsx
@@ -4,14 +4,13 @@ import { SDKCards, SDKCardsProps } from "."
 export default {
   component: SDKCards,
   title: "Components/SDKCards",
+  parameters: {
+    layout: "centered",
+  },
 } as Meta
 
 const Template: Story<SDKCardsProps> = (args) => {
-  return (
-    <div className="bg-gray-100 p-4 dark:bg-black">
-      <SDKCards {...args} />
-    </div>
-  )
+  return <SDKCards {...args} />
 }
 
 export const Primary = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/SporksCard/SporksCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/SporksCard/SporksCard.stories.tsx
@@ -5,14 +5,13 @@ import { endOfDay, endOfWeek } from "date-fns"
 export default {
   component: SporksCard,
   title: "Components/SporksCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<SporksCardProps> = (args) => {
-  return (
-    <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-      <SporksCard {...args} />
-    </div>
-  )
+  return <SporksCard {...args} />
 }
 
 const args = {

--- a/app/ui/design-system/src/lib/Components/StaticCheckbox/StaticCheckbox.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/StaticCheckbox/StaticCheckbox.stories.tsx
@@ -4,6 +4,9 @@ import { InputProps, StaticCheckbox } from "."
 export default {
   component: StaticCheckbox,
   title: "Components/StaticCheckbox",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<InputProps> = (args) => <StaticCheckbox {...args} />

--- a/app/ui/design-system/src/lib/Components/ToggleButton/ToggleButton.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ToggleButton/ToggleButton.stories.tsx
@@ -13,6 +13,9 @@ export default {
       control: { type: "select" },
     },
   },
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<ToggleButtonProps> = (args) => {
@@ -20,7 +23,6 @@ const Template: Story<ToggleButtonProps> = (args) => {
     <div
       style={{
         gap: "1rem",
-        padding: "1rem",
         display: "inline-flex",
         flexDirection: "column",
       }}

--- a/app/ui/design-system/src/lib/Components/ToolCard/ToolCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ToolCard/ToolCard.stories.tsx
@@ -4,14 +4,13 @@ import { ToolCard, ToolCardProps } from "."
 export default {
   component: ToolCard,
   title: "Components/ToolCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<ToolCardProps> = (args) => {
-  return (
-    <div className="bg-gray-100 p-4 dark:bg-black">
-      <ToolCard {...args} />
-    </div>
-  )
+  return <ToolCard {...args} />
 }
 
 export const Primary = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/ToolsAndConcepts/ToolsAndConcepts.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ToolsAndConcepts/ToolsAndConcepts.stories.tsx
@@ -1,10 +1,12 @@
 import { Meta, Story } from "@storybook/react"
 import ToolsAndConcepts, { ToolsAndConceptsProps } from "."
-import PageBackground from "../../Pages/shared/PageBackground"
 
 export default {
   component: ToolsAndConcepts,
   title: "Components/ToolsAndConcepts",
+  parameters: {
+    layout: "centered",
+  },
 } as Meta
 
 const tutorialCard = {
@@ -19,11 +21,7 @@ const tutorialCard = {
 }
 
 const Template: Story<ToolsAndConceptsProps> = (args) => {
-  return (
-    <PageBackground className="bg-primary-gray-50 py-6 dark:bg-black">
-      <ToolsAndConcepts {...args} />
-    </PageBackground>
-  )
+  return <ToolsAndConcepts {...args} />
 }
 
 const tools = Array(6).fill({

--- a/app/ui/design-system/src/lib/Components/TutorialCard/TutorialCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/TutorialCard/TutorialCard.stories.tsx
@@ -4,13 +4,12 @@ import TutorialCard, { TutorialCardProps } from "."
 export default {
   component: TutorialCard,
   title: "Components/TutorialCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
-const Template: Story<TutorialCardProps> = (args) => (
-  <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-    <TutorialCard {...args} />
-  </div>
-)
+const Template: Story<TutorialCardProps> = (args) => <TutorialCard {...args} />
 
 const args = {
   heading: "This is a title with a header in a two line sentence",

--- a/app/ui/design-system/src/lib/Components/UpcomingEvents/UpcomingEvents.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/UpcomingEvents/UpcomingEvents.stories.tsx
@@ -4,12 +4,13 @@ import { UpcomingEvents, UpcomingEventsProps } from "."
 export default {
   component: UpcomingEvents,
   title: "Components/UpcomingEvents",
+  parameters: {
+    layout: "centered",
+  },
 } as Meta
 
 const Template: Story<UpcomingEventsProps> = (args) => (
-  <div className="bg-primary-gray-50 dark:bg-black" style={{ padding: "14px" }}>
-    <UpcomingEvents {...args} />
-  </div>
+  <UpcomingEvents {...args} />
 )
 
 const upcomingEvents = [

--- a/app/ui/design-system/src/lib/Components/VideoCard/VideoCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/VideoCard/VideoCard.stories.tsx
@@ -6,15 +6,16 @@ import { SmallVideoCard, SmallVideoCardProps } from "./SmallVideoCard"
 export default {
   component: LargeVideoCard,
   title: "Components/VideoCard",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const LargeTemplate: Story<LargeVideoCardProps> = (args) => (
   <LargeVideoCard {...args} />
 )
 const SmallTemplate: Story<SmallVideoCardProps> = (args) => (
-  <div style={{ backgroundColor: "#f1f1f1", padding: "14px" }}>
-    <SmallVideoCard {...args} />
-  </div>
+  <SmallVideoCard {...args} />
 )
 const SmallDarkTemplate: Story<SmallVideoCardProps> = (args) => (
   <SmallVideoCard {...args} />

--- a/app/ui/design-system/src/lib/Pages/GettingStartedPage/GettingStartedPage.stories.tsx
+++ b/app/ui/design-system/src/lib/Pages/GettingStartedPage/GettingStartedPage.stories.tsx
@@ -363,6 +363,7 @@ const gettingStartedPageData = {
 export default {
   component: GettingStartedPage,
   title: "Pages/GettingStartedPage",
+  excludeStories: ["Icon1", "Icon2", "Icon3"],
 } as Meta
 
 const Template: Story<GettingStartedPageProps> = (args) => {

--- a/app/ui/design-system/src/lib/Pages/InternalPage/InternalPage.stories.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/InternalPage.stories.tsx
@@ -4,14 +4,13 @@ import { InternalPage } from "."
 export default {
   component: InternalPage,
   title: "Pages/InternalPage",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story = (args) => {
-  return (
-    <div style={{ padding: "1rem" }}>
-      <InternalPage />
-    </div>
-  )
+  return <InternalPage />
 }
 
 export const Primary = Template.bind({})


### PR DESCRIPTION
Just some minor storybook enhancements for consideration:

- Sets default light background to match the real site background (`bg-primary-gray-50`, i.e. #f6f7f9)
- Use "padded" layout instead of wrapping stories in divs with explicit styles. 
- Set "dark" and "root" classes on the document root instead of a child div (it was causing weird issues with dark mode not rendering correctly)