### PR TITLE
Change default ToolCard/SdkCard image (+dark mode)

### DIFF
--- a/app/ui/design-system/images/content/code-light.svg
+++ b/app/ui/design-system/images/content/code-light.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 18L22 12L16 6" stroke="#F6F7F9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 6L2 12L8 18" stroke="#F6F7F9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/ui/design-system/src/lib/Components/SDKCard/SDKCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/SDKCard/SDKCard.stories.tsx
@@ -23,7 +23,6 @@ Default.args = {
   link: "#",
   type: "sdk",
   stars: 52,
-  iconSrc: "https://avatars.githubusercontent.com/u/62387156?s=64&v=4",
   lastCommit: "22/3",
   lastRelease: "207",
 }

--- a/app/ui/design-system/src/lib/Components/SDKCard/index.tsx
+++ b/app/ui/design-system/src/lib/Components/SDKCard/index.tsx
@@ -1,7 +1,8 @@
 import { ReactComponent as CalendarIcon } from "../../../../images/action/date-calendar"
 import { ReactComponent as StarIcon } from "../../../../images/action/star"
 import { ReactComponent as CommitIcon } from "../../../../images/content/commit"
-import FlowIconSrc from "../../../../images/logos/flow-icon.svg"
+import CodeIconSrc from "../../../../images/content/code.svg"
+import CodeIconLightSrc from "../../../../images/content/code-light.svg"
 import Tag from "../Tag"
 
 export type SDKCardProps = {
@@ -14,6 +15,7 @@ export type SDKCardProps = {
   lastCommit?: string
   lastRelease?: string
   iconSrc?: string
+  iconDarkModeSrc?: string
   description?: string
 }
 
@@ -24,18 +26,30 @@ export function SDKCard({
   tags,
   link,
   stars,
-  iconSrc = FlowIconSrc,
+  iconSrc,
+  iconDarkModeSrc,
   lastCommit,
   lastRelease,
   description,
 }: SDKCardProps) {
   return (
     <a
-      className="flex gap-4 rounded-lg bg-white py-6 px-8 hover:shadow-2xl dark:bg-primary-gray-dark dark:hover:shadow-2xl-dark"
+      className="flex gap-4 rounded-lg bg-white py-6 px-8 hover:shadow-2xl dark:bg-primary-gray-dark dark:text-white dark:hover:shadow-2xl-dark"
       href={link}
     >
       <div>
-        <img src={iconSrc} alt={title} width={64} />
+        <img
+          className="dark:hidden"
+          src={iconSrc || CodeIconSrc}
+          alt={title}
+          width={64}
+        />
+        <img
+          className="hidden dark:block"
+          src={iconDarkModeSrc || iconSrc || CodeIconLightSrc}
+          alt={title}
+          width={64}
+        />
       </div>
       <div className="grow">
         <h5 className="text-h5">{title}</h5>

--- a/app/ui/design-system/src/lib/Components/SDKCards/SDKCards.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/SDKCards/SDKCards.stories.tsx
@@ -25,7 +25,6 @@ Primary.args = {
       link: "#",
       type: "sdk",
       stars: 52,
-      iconSrc: "https://avatars.githubusercontent.com/u/62387156?s=64&v=4",
       lastCommit: "22/3",
       lastRelease: "207",
     },

--- a/app/ui/design-system/src/lib/Components/ToolCard/ToolCard.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ToolCard/ToolCard.stories.tsx
@@ -20,7 +20,6 @@ Primary.args = {
   authorName: "mini flow",
   description:
     "Lorem ipsum text here can go a two liner sentence or a one liner",
-  iconSrc: "https://avatars.githubusercontent.com/u/62387156?s=64&v=4",
   link: "#",
   stars: 52,
   tags: ["Tags"],

--- a/app/ui/design-system/src/lib/Components/ToolCard/index.tsx
+++ b/app/ui/design-system/src/lib/Components/ToolCard/index.tsx
@@ -1,5 +1,6 @@
 import { ReactComponent as StarIcon } from "../../../../images/action/star"
-import FlowIconSrc from "../../../../images/logos/flow-icon.svg"
+import CodeIconSrc from "../../../../images/content/code.svg"
+import CodeIconLightSrc from "../../../../images/content/code-light.svg"
 import Tag from "../Tag"
 
 export type ToolCardProps = {
@@ -7,6 +8,7 @@ export type ToolCardProps = {
   authorName?: string
   description?: string
   iconSrc?: string
+  iconDarkModeSrc?: string
   link: string
   stars?: number
   tags?: string[]
@@ -17,7 +19,8 @@ export function ToolCard({
   authorIcon,
   authorName,
   description,
-  iconSrc = FlowIconSrc,
+  iconSrc,
+  iconDarkModeSrc,
   link,
   stars,
   tags,
@@ -25,11 +28,22 @@ export function ToolCard({
 }: ToolCardProps) {
   return (
     <a
-      className="flex gap-4 rounded-lg bg-white py-6 px-8 hover:shadow-2xl dark:bg-primary-gray-dark dark:hover:shadow-2xl-dark"
+      className="flex gap-4 rounded-lg bg-white py-6 px-8 hover:shadow-2xl dark:bg-primary-gray-dark dark:text-white dark:hover:shadow-2xl-dark"
       href={link}
     >
       <div>
-        <img src={iconSrc} alt={title} width={64} />
+        <img
+          className="dark:hidden"
+          src={iconSrc || CodeIconSrc}
+          alt={title}
+          width={64}
+        />
+        <img
+          className="hidden dark:block"
+          src={iconDarkModeSrc || iconSrc || CodeIconLightSrc}
+          alt={title}
+          width={64}
+        />
       </div>
       <div className="grow">
         <h5 className="text-h5">{title}</h5>

--- a/app/ui/design-system/src/lib/Components/ToolsAndConcepts/ToolsAndConcepts.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ToolsAndConcepts/ToolsAndConcepts.stories.tsx
@@ -33,7 +33,6 @@ const tools = Array(6).fill({
   tags: ["Tags"],
   link: "#",
   stars: 52,
-  iconSrc: "https://avatars.githubusercontent.com/u/62387156?s=64&v=4",
   description:
     "Lorem ipsum text here can go a two liner sentence or a one liner",
 })


### PR DESCRIPTION
Per #247 this changes the default icon used on the `ToolCard` and `SDKCard`. 

Also desired is changing the icon color in dark mode. Because the icon is passed in as a URL (via the `iconSrc` prop) we can't do this via CSS. So I've added an optional `iconDarkModeSrc` prop which allows a different icon to be used for dark mode. By default this uses the `iconSrc` value, except in the case where we're using the _default_ `iconSrc`, where we use the dark version.

Note that the "dark mode" icon is named `code-light.svg`, which may seem backwards, but I did this for consistency - we use this same convention with `flow-docs-logo.svg` and `flow-docs-logo-light.svg`. The "light" is actually indicating the icon color/style itself. 

Light mode:
<img width="486" alt="Screen Shot 2022-06-21 at 11 46 25 AM" src="https://user-images.githubusercontent.com/393220/174842391-cc703dd1-4f59-4268-98e3-5b0d8f4b52ec.png">

Dark mode:\
<img width="477" alt="Screen Shot 2022-06-21 at 11 46 35 AM" src="https://user-images.githubusercontent.com/393220/174842392-ffe91c4f-687b-491d-8471-4612d06c9e3e.png">

