### PR TITLE
Change tools page header image

### DIFF
--- a/app/ui/design-system/src/lib/Components/ForumCell/ForumCell.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/ForumCell/ForumCell.stories.tsx
@@ -42,6 +42,7 @@ const args = {
     },
   ],
   forumLink: "#test",
+  lastUpdatedDate: "2022-06-06",
 }
 
 Default.args = args

--- a/app/ui/design-system/src/lib/Components/LandingHeader/index.tsx
+++ b/app/ui/design-system/src/lib/Components/LandingHeader/index.tsx
@@ -61,8 +61,12 @@ export function LandingHeader({
             {buttonText}
           </ButtonLink>
         </div>
-        <div className="hidden rounded-r-lg border px-10 py-6 dark:bg-white/40 md:block md:block md:basis-1/2 md:px-20 md:py-12">
-          <img src={imageSrc} alt={title} />
+        <div className="hidden items-center justify-center rounded-r-lg border px-10 py-6 dark:bg-white/40 md:flex md:basis-1/2 md:px-20 md:py-12">
+          <img
+            src={imageSrc}
+            alt={title}
+            className="max-h-[340px] max-w-[570px]"
+          />
         </div>
       </div>
       <LandingHeaderLinks />

--- a/app/ui/design-system/src/lib/Pages/ToolsPage/ToolsPage.stories.tsx
+++ b/app/ui/design-system/src/lib/Pages/ToolsPage/ToolsPage.stories.tsx
@@ -53,7 +53,17 @@ const args = {
       icon: "concepts",
     },
   ],
-  apis: Array(6).fill({
+  apisAndServices: Array(6).fill({
+    heading: "Such title, much heading",
+    tags: ["Tool"],
+    description: "An online contest that lorem ipsum ipsums ipsum",
+    lastUpdated: "23/3/2022",
+    level: "Beginners",
+    imageUri:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/A_black_image.jpg/2560px-A_black_image.jpg",
+    link: "/tutorials",
+  }),
+  explorers: Array(6).fill({
     heading: "Such title, much heading",
     tags: ["Tool"],
     description: "An online contest that lorem ipsum ipsums ipsum",

--- a/app/ui/design-system/src/lib/Pages/ToolsPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/ToolsPage/index.tsx
@@ -5,14 +5,13 @@ import {
 import { LandingHeader } from "../../Components/LandingHeader"
 import { SDKCardProps } from "../../Components/SDKCard"
 import { SDKCards } from "../../Components/SDKCards"
-import { ToolCardProps } from "../../Components/ToolCard"
 import PageBackground from "../shared/PageBackground"
 import PageSection from "../shared/PageSection"
 import PageSections from "../shared/PageSections"
-// import Arches from "../../../../images/misc/arches.png"
+import ArchesImageSrc from "../../../../images/misc/arches.png"
 
 export type ToolsPageProps = {
-  tools: ToolCardProps[]
+  tools: SDKCardProps[]
   sdks: SDKCardProps[]
   explorers: SDKCardProps[]
   apisAndServices: SDKCardProps[]
@@ -40,7 +39,7 @@ const ToolsPage = ({
             callout="Flow Dapp Architecture Guide"
             description="Wondering what tools you need? See our dapp architectures guide to help you out."
             title="Tools"
-            // imageSrc={Arches} TODO: FIX.
+            imageSrc={ArchesImageSrc}
           />
         </PageSection>
         <PageSection>


### PR DESCRIPTION
Updates the tools page to use the "arches.png" image in it's header:

<img width="1164" alt="Screen Shot 2022-06-21 at 12 21 30 PM" src="https://user-images.githubusercontent.com/393220/174849425-cf2decd6-6057-4d8f-9e24-1accfcb43585.png">

<img width="1149" alt="Screen Shot 2022-06-21 at 12 21 26 PM" src="https://user-images.githubusercontent.com/393220/174849424-e1af7d38-98d7-42a3-b33a-27e5c26db6c0.png">

#247
