### PR TITLE
Redirect incomplete pages to a coming soon page

### DIFF
--- a/app/routes/$repo.tsx
+++ b/app/routes/$repo.tsx
@@ -5,6 +5,7 @@ import { repoList, repoPresets } from "~/constants/repos"
 import { RepoSchema } from "~/constants/repos/repo-schema"
 import { ErrorPage } from "~/ui/design-system/src/lib/Components/ErrorPage"
 import { InternalSidebar } from "~/ui/design-system/src/lib/Components/InternalSidebar"
+import { temporarilyRedirectToComingSoon } from "~/utils/features"
 
 type LoaderData = {
   repo: string
@@ -15,6 +16,8 @@ export const loader: LoaderFunction = async ({
   params,
 }): Promise<LoaderData> => {
   invariant(params.repo, `expected repo param`)
+
+  temporarilyRedirectToComingSoon()
 
   const isKnownRepo = repoList.map((r) => r.repo).includes(params.repo)
   if (!isKnownRepo) {

--- a/app/routes/coming-soon.tsx
+++ b/app/routes/coming-soon.tsx
@@ -1,0 +1,24 @@
+import { MetaFunction } from "@remix-run/node"
+import { PageBackground } from "~/ui/design-system"
+import PageSection from "~/ui/design-system/src/lib/Pages/shared/PageSection"
+import PageSections from "~/ui/design-system/src/lib/Pages/shared/PageSections"
+
+export const meta: MetaFunction = () => {
+  return { title: `Coming soon` }
+}
+
+export default function ComingSoon() {
+  return (
+    <PageBackground gradient="tools">
+      <PageSections>
+        <PageSection className="min-h-[2000px] pt-0 pb-0">
+          <div className="container mx-auto flex flex-col justify-items-stretch py-16 md:py-32">
+            <h1 className="text-h1 mb-14 max-w-full overflow-hidden text-ellipsis !text-4xl md:mt-12 md:!text-7xl md:!leading-tight">
+              Coming soon
+            </h1>
+          </div>
+        </PageSection>
+      </PageSections>
+    </PageBackground>
+  )
+}

--- a/app/routes/community/index.tsx
+++ b/app/routes/community/index.tsx
@@ -9,6 +9,7 @@ import { Default as DefaultUpcomingEvents } from "~/ui/design-system/src/lib/Com
 import CommunityPage, {
   CommunityPageProps,
 } from "~/ui/design-system/src/lib/Pages/CommunityPage"
+import { temporarilyRedirectToComingSoon } from "~/utils/features"
 import { articles, contentNavigationItems, projects, tools } from "./data"
 
 type DynamicCommunityPageProps = Pick<
@@ -22,6 +23,7 @@ type DynamicCommunityPageProps = Pick<
 >
 
 export const loader: LoaderFunction = async () => {
+  temporarilyRedirectToComingSoon()
   const { openFlips, goodPlacesToStartFlips } = await fetchFlips()
   const upcomingEvents = DefaultUpcomingEvents?.args as UpcomingEventsProps
   const forumTopics = await fetchLatestTopics()

--- a/app/routes/concepts/index.tsx
+++ b/app/routes/concepts/index.tsx
@@ -1,5 +1,11 @@
+import { LoaderFunction } from "@remix-run/node"
+import { temporarilyRedirectToComingSoon } from "~/utils/features"
 import { ConceptsPage } from "../../ui/design-system/src/lib/Pages/ConceptsPage"
 import { data } from "./data"
+
+export const loader: LoaderFunction = async () => {
+  temporarilyRedirectToComingSoon()
+}
 
 export default function Page() {
   return <ConceptsPage {...data} />

--- a/app/routes/learn/index.tsx
+++ b/app/routes/learn/index.tsx
@@ -1,5 +1,12 @@
+import { LoaderFunction } from "@remix-run/node"
 import { LearnPage } from "~/ui/design-system/src/lib/Pages/LearnPage"
+import { temporarilyRedirectToComingSoon } from "~/utils/features"
 import { data } from "./data"
+
+export const loader: LoaderFunction = () => {
+  temporarilyRedirectToComingSoon()
+  return {}
+}
 
 export default function Page() {
   return (

--- a/app/routes/network/index.tsx
+++ b/app/routes/network/index.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunction, redirect } from "@remix-run/node"
+import { LoaderFunction } from "@remix-run/node"
 import { useLoaderData } from "@remix-run/react"
 import { fetchNetworkStatus } from "~/cms/utils/fetch-network-status"
 import NetworkPage, {

--- a/app/routes/network/index.tsx
+++ b/app/routes/network/index.tsx
@@ -1,14 +1,17 @@
-import { LoaderFunction } from "@remix-run/node"
+import { LoaderFunction, redirect } from "@remix-run/node"
 import { useLoaderData } from "@remix-run/react"
 import { fetchNetworkStatus } from "~/cms/utils/fetch-network-status"
 import NetworkPage, {
   NetworkPageProps,
 } from "~/ui/design-system/src/lib/Pages/NetworkPage"
+import { temporarilyRedirectToComingSoon } from "~/utils/features"
 import { featuredArticle } from "./data"
 
 type DynamicNetworkPageProps = Pick<NetworkPageProps, "networkStatuses">
 
 export const loader: LoaderFunction = async () => {
+  temporarilyRedirectToComingSoon()
+
   const networkStatuses = await fetchNetworkStatus()
   const data = { networkStatuses }
   return data

--- a/app/routes/sdks/index.tsx
+++ b/app/routes/sdks/index.tsx
@@ -1,6 +1,8 @@
 import { LoaderFunction } from "@remix-run/server-runtime"
+import { temporarilyRedirectToComingSoon } from "~/utils/features"
 
 export const loader: LoaderFunction = async () => {
+  temporarilyRedirectToComingSoon()
   return {}
 }
 

--- a/app/utils/features.ts
+++ b/app/utils/features.ts
@@ -1,0 +1,12 @@
+import { redirect } from "@remix-run/node"
+
+/**
+ * @see https://github.com/onflow/next-docs-v1/issues/260
+ */
+export function temporarilyRedirectToComingSoon() {
+  // alternatively: allow these pages to load in dev
+  // if (process.env.NODE_ENV === "production") {
+  //   throw redirect(`/coming-soon`)
+  // }
+  throw redirect(`/coming-soon`)
+}


### PR DESCRIPTION
Fixes #260 

- add coming soon page
- Redirect to coming soon on community, concepts, lean, network, sdks etc

<img width="1388" alt="image" src="https://user-images.githubusercontent.com/921605/174857245-b658d173-63ac-41d4-9423-2fb23ced959b.png">
