### PR TITLE
Add suggested links to coming soon page

### DIFF
--- a/app/routes/coming-soon.tsx
+++ b/app/routes/coming-soon.tsx
@@ -1,4 +1,5 @@
 import { MetaFunction } from "@remix-run/node"
+import { Link as RLink, LinkProps } from "@remix-run/react"
 import { PageBackground } from "~/ui/design-system"
 import PageSection from "~/ui/design-system/src/lib/Pages/shared/PageSection"
 import PageSections from "~/ui/design-system/src/lib/Pages/shared/PageSections"
@@ -16,9 +17,21 @@ export default function ComingSoon() {
             <h1 className="text-h1 mb-14 max-w-full overflow-hidden text-ellipsis !text-4xl md:mt-12 md:!text-7xl md:!leading-tight">
               Coming soon
             </h1>
+            <div>
+              Visit our <Link to="/">homepage</Link>,{" "}
+              <Link to="/getting-started">getting-started</Link>, and{" "}
+              <Link to="/tools">tools</Link> instead.
+            </div>
           </div>
         </PageSection>
       </PageSections>
     </PageBackground>
   )
 }
+
+const Link = (props: LinkProps) => (
+  <RLink
+    className="text-primary-blue hover:opacity-75 dark:border-blue-dark dark:stroke-blue-dark dark:text-blue-dark"
+    {...props}
+  />
+)

--- a/app/utils/features.ts
+++ b/app/utils/features.ts
@@ -4,9 +4,11 @@ import { redirect } from "@remix-run/node"
  * @see https://github.com/onflow/next-docs-v1/issues/260
  */
 export function temporarilyRedirectToComingSoon() {
-  // alternatively: allow these pages to load in dev
-  // if (process.env.NODE_ENV === "production") {
-  //   throw redirect(`/coming-soon`)
-  // }
-  throw redirect(`/coming-soon`)
+  const isPreview =
+    process.env.INCOMPLETE_PAGE_BEHAVIOR === "preview" || // allow envs like staging to preview incomplete pages
+    process.env.NODE_ENV === "development" // assume people want to see these pages in dev
+
+  if (!isPreview) {
+    throw redirect(`/coming-soon`)
+  }
 }


### PR DESCRIPTION
- Add suggestions to coming soon page
- Allow previewing incomplete routes on staging and in dev via `INCOMPLETE_PAGE_BEHAVIOR` env var

<img width="1900" alt="image" src="https://user-images.githubusercontent.com/921605/174870842-f13b3533-d331-40cc-a9a0-7c144a685842.png">
