### PR TITLE
Update Nav bar intro card indicator colors

### DIFF
--- a/app/ui/design-system/src/lib/Components/NavigationBar/IntroCardCarousel.tsx
+++ b/app/ui/design-system/src/lib/Components/NavigationBar/IntroCardCarousel.tsx
@@ -11,7 +11,8 @@ export function IntroCardCarousel({ cards }: IntroCardCarouselProps) {
       breakpoint="none"
       carouselItemWidth="w-full"
       className="w-72 rounded-md bg-primary-gray-50 px-8 pt-6 pb-4 dark:bg-black"
-      indicatorSelectedColor="bg-primary-gray-300"
+      indicatorColor="bg-primary-gray-100 dark:bg-primary-gray-300"
+      indicatorSelectedColor="bg-primary-gray-300 dark:bg-white"
       indicatorSize="xs"
     >
       {cards.map((card, index) => (


### PR DESCRIPTION
Reverses the indicator colors in the nav bar carousel In dark mode:

<img width="335" alt="Screen Shot 2022-06-21 at 2 31 42 PM" src="https://user-images.githubusercontent.com/393220/174872854-35dcfbfc-00d2-4f88-bf41-c1e37f502302.png">

Light mode remains the same:

<img width="306" alt="Screen Shot 2022-06-21 at 2 31 36 PM" src="https://user-images.githubusercontent.com/393220/174872853-e16a4974-f797-4979-9e55-6df992b83a2e.png">

This doesn't affect any other carousels because the navbar overrides the default colors.