### PR TITLE
Adds breadcrumb navigation to internal pages

### DIFF
--- a/app/routes/$repo.tsx
+++ b/app/routes/$repo.tsx
@@ -1,11 +1,17 @@
 import { json, LoaderFunction } from "@remix-run/node"
-import { Link, Outlet, useCatch, useLoaderData } from "@remix-run/react"
+import {
+  Link,
+  Outlet,
+  useCatch,
+  useLoaderData,
+  useMatches,
+} from "@remix-run/react"
 import invariant from "tiny-invariant"
 import { repoList, repoPresets } from "~/constants/repos"
 import { RepoSchema } from "~/constants/repos/repo-schema"
 import { ErrorPage } from "~/ui/design-system/src/lib/Components/ErrorPage"
-import { InternalSidebar } from "~/ui/design-system/src/lib/Components/InternalSidebar"
 import { temporarilyRedirectToComingSoon } from "~/utils/features"
+import { InternalPage } from "../ui/design-system/src/lib/Pages/InternalPage"
 
 type LoaderData = {
   repo: string
@@ -38,17 +44,17 @@ export const loader: LoaderFunction = async ({
 
 export default function Repo() {
   const data = useLoaderData<LoaderData>()
+  const matches = useMatches()
+  const [match] = matches.slice(-1)
+
   return (
-    <div className="flex h-full">
-      {data.repoSchema ? (
-        <InternalSidebar config={data.repoSchema.sidebar} />
-      ) : (
-        <div>⚠️ D'oh. Failed to load sidebar content.</div>
-      )}
-      <div className="overflow-auto">
-        <Outlet />
-      </div>
-    </div>
+    <InternalPage
+      activePath={match.params["*"] || "index"}
+      repo={data.repo}
+      sidebarConfig={data.repoSchema?.sidebar}
+    >
+      <Outlet />
+    </InternalPage>
   )
 }
 

--- a/app/ui/design-system/src/lib/Components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -13,7 +13,11 @@ const Template: Story<BreadcrumbsProps> = (args) => <Breadcrumbs {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  current: "Quick reference",
+  items: [
+    { href: "#home", name: "Home" },
+    { href: "#tool", name: "Tool" },
+    { href: "#quick-reference", name: "Quick reference" },
+  ],
 }
 
 export const dark = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/Breadcrumbs/index.tsx
+++ b/app/ui/design-system/src/lib/Components/Breadcrumbs/index.tsx
@@ -1,5 +1,15 @@
+import clsx from "clsx"
+import { Fragment } from "react"
+
+export type BreadcrumbLinkProps = {
+  name: string
+  href?: string
+  isCurrent?: boolean
+}
+
 export type BreadcrumbsProps = {
-  current?: string
+  items: BreadcrumbLinkProps[]
+  className?: string
 }
 
 function Separator() {
@@ -10,31 +20,42 @@ function Separator() {
   )
 }
 
-function BreadcrumbLink({ name, href }: { name: string; href: string }) {
+function BreadcrumbLink({
+  name,
+  href,
+  isCurrent = false,
+}: BreadcrumbLinkProps) {
+  const className = clsx(
+    isCurrent && "CURRENT text-primary-gray-400 dark:text-primary-gray-100",
+    !isCurrent && "NOT_CURRENT text-primary-gray-300 dark:text-primary-gray-200"
+  )
+
+  if (!href) {
+    return <span className={className}>{name}</span>
+  }
+
   return (
     <a
       href={href}
-      className="text-primary-gray-300 hover:text-primary-gray-400 dark:text-primary-gray-200 dark:hover:text-primary-gray-100"
+      className={clsx(
+        className,
+        "hover:text-primary-gray-400 dark:hover:text-primary-gray-100"
+      )}
     >
       {name}
     </a>
   )
 }
 
-export function Breadcrumbs({ current }: BreadcrumbsProps) {
+export function Breadcrumbs({ className, items }: BreadcrumbsProps) {
   return (
-    <div className="flex flex-wrap items-center text-sm">
-      <BreadcrumbLink name="Home" href="#" />
-      <Separator />
-      <BreadcrumbLink name="Tool" href="#" />
-      {!!current && (
-        <>
-          <Separator />
-          <div className="text-primary-gray-400 dark:text-primary-gray-100">
-            {current}
-          </div>
-        </>
-      )}
+    <div className={clsx("flex flex-wrap items-center text-sm", className)}>
+      {items.map((item, index) => (
+        <Fragment key={index}>
+          {index > 0 && <Separator />}
+          <BreadcrumbLink {...item} isCurrent={index === items.length - 1} />
+        </Fragment>
+      ))}
     </div>
   )
 }

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
@@ -6,7 +6,7 @@ type InternalSidebarSectionItem = {
   href: string
 }
 
-type InternalSidebarSection = {
+export type InternalSidebarSection = {
   title: string
   items: InternalSidebarSectionItem[]
 }

--- a/app/ui/design-system/src/lib/Pages/InternalPage/InternalPage.stories.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/InternalPage.stories.tsx
@@ -1,5 +1,6 @@
+import { MemoryRouter } from "react-router"
 import { Meta, Story } from "@storybook/react"
-import { InternalPage } from "."
+import { InternalPage, InternalPageProps } from "."
 
 export default {
   component: InternalPage,
@@ -9,12 +10,48 @@ export default {
   },
 } as Meta
 
-const Template: Story = (args) => {
-  return <InternalPage />
+const Template: Story<InternalPageProps> = (args) => {
+  return (
+    <MemoryRouter initialEntries={[`/${args.activePath}`]}>
+      <InternalPage {...args} />
+    </MemoryRouter>
+  )
 }
 
 export const Primary = Template.bind({})
+Primary.args = {
+  activePath: "internal/item2",
+  repo: "foo",
+  sidebarConfig: {
+    sections: [
+      {
+        title: "A section title",
+        items: [
+          {
+            href: "internal/item1",
+            label: "An item within a section",
+          },
+          {
+            href: "internal/item2",
+            label: "The active item",
+          },
+          {
+            href: "internal/item3",
+            label: "Another item",
+          },
+          {
+            href: "internal/item4",
+            label: "Blah blah blah",
+          },
+        ],
+      },
+    ],
+  },
+  children: "[Page content placeholder]",
+} as InternalPageProps
+
 export const PrimaryDark = Template.bind({})
+PrimaryDark.args = { ...Primary.args }
 PrimaryDark.parameters = {
   backgrounds: {
     default: "dark",
@@ -22,6 +59,7 @@ PrimaryDark.parameters = {
 }
 
 export const PrimaryMobile = Template.bind({})
+PrimaryMobile.args = { ...Primary.args }
 PrimaryMobile.parameters = {
   viewport: {
     defaultViewport: "xs",

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -1,104 +1,37 @@
-export function InternalPage() {
+import { Breadcrumbs } from "../../Components/Breadcrumbs"
+import { InternalSidebar } from "../../Components/InternalSidebar"
+import {
+  useInternalBreadcrumbs,
+  UseInternalBreadcrumbsOptions,
+} from "./useInternalBreadcrumbs"
+
+export type InternalPageProps = React.PropsWithChildren<{}> &
+  UseInternalBreadcrumbsOptions
+
+export function InternalPage({
+  activePath,
+  rootUrl = "/",
+  children,
+  repo,
+  sidebarConfig,
+}: InternalPageProps) {
+  const breadcrumbs = useInternalBreadcrumbs({
+    activePath,
+    rootUrl,
+    sidebarConfig,
+    repo,
+  })
+
   return (
-    <div className="mdx-content">
-      <table>
-        <thead>
-          <tr>
-            <th align="left">Node Operator</th>
-            <th align="left">SDKs</th>
-            <th align="left">TOOLS</th>
-            <th align="left">Left-aligned</th>
-            <th align="center">Center-aligned</th>
-            <th align="right">Right-aligned</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td align="left">Text</td>
-            <td align="left">Text</td>
-            <td align="left">Text</td>
-            <td align="left">git status</td>
-            <td align="center">git status</td>
-            <td align="right">git status</td>
-          </tr>
-          <tr>
-            <td align="left">Text</td>
-            <td align="left">Text</td>
-            <td align="left">Text</td>
-            <td align="left">git diff</td>
-            <td align="center">git diff</td>
-            <td align="right">git diff</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <br />
-
-      <p>
-        This is a reference
-        <sup>
-          <a href="#user-content-fn-1">
-            <span className="undefined mr-1">[1]</span>
-          </a>
-        </sup>
-      </p>
-
-      <p>
-        This is another reference
-        <sup>
-          <a href="#user-content-fn-1">
-            <span className="undefined mr-1">[1]</span>
-          </a>
-        </sup>
-      </p>
-
-      <section data-footnotes="true" className="footnotes">
-        <h2 id="footnotes" className="sr-only mt-6 mb-6 text-2xl font-semibold">
-          <div className="group -ml-11 flex">
-            <a
-              href="#footnotes"
-              title="Footnotes"
-              className="mr-3 flex h-8 w-8 scale-75 items-center justify-center rounded-md bg-gray-100 hover:bg-gray-200 group-hover:visible dark:bg-primary-gray-dark dark:hover:bg-gray-700 md:invisible md:scale-100"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                fill="none"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fill="#3B3CFF"
-                  d="M9.778 13.511L8.41 14.867a2.222 2.222 0 01-3.122 0 2.178 2.178 0 010-3.084L7.894 9.2a2.222 2.222 0 013.123 0c.264.263.456.59.555.95.055-.045.105-.095.15-.15l.717-.711a3.273 3.273 0 00-.64-.9 3.334 3.334 0 00-4.688 0L4.5 10.994a3.283 3.283 0 000 4.662 3.333 3.333 0 004.689 0l2.028-2.012h-.278a4.441 4.441 0 01-1.161-.133z"
-                ></path>
-                <path
-                  fill="#3B3CFF"
-                  d="M15.894 4.344a3.333 3.333 0 00-4.688 0L9.178 6.356h.272c.394 0 .786.052 1.167.155l1.366-1.355a2.222 2.222 0 013.122 0 2.178 2.178 0 010 3.083L12.5 10.822a2.222 2.222 0 01-3.122 0 2.144 2.144 0 01-.556-.95c-.055.038-.107.08-.155.128l-.717.711c.16.334.376.639.639.9a3.333 3.333 0 004.689 0l2.605-2.583a3.29 3.29 0 000-4.661l.011-.023z"
-                ></path>
-              </svg>
-            </a>
-            Footnotes
-          </div>
-        </h2>
-        <ol>
-          <li id="user-content-fn-1">
-            <p>
-              This is a reference{" "}
-              <a href="#user-content-fnref-1">
-                <span className="data-footnote-backref mr-1">↩</span>
-              </a>
-            </p>
-          </li>
-          <li id="user-content-fn-1">
-            <p>
-              This is another reference{" "}
-              <a href="#user-content-fnref-2">
-                <span className="data-footnote-backref mr-1">↩</span>
-              </a>
-            </p>
-          </li>
-        </ol>
-      </section>
+    <div className="flex flex-col">
+      <Breadcrumbs
+        className="sticky top-0 z-10 border-b bg-white px-4 py-2 dark:bg-black lg:px-8"
+        items={breadcrumbs}
+      />
+      <div className="flex flex-1 flex-row overflow-auto">
+        {sidebarConfig && <InternalSidebar config={sidebarConfig} />}
+        <div className="flex-1 overflow-auto">{children}</div>
+      </div>
     </div>
   )
 }

--- a/app/ui/design-system/src/lib/Pages/InternalPage/useInternalBreadcrumbs.ts
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/useInternalBreadcrumbs.ts
@@ -1,0 +1,62 @@
+import { useMemo } from "react"
+import { InternalSidebarConfig } from "../../Components/InternalSidebar"
+
+export type UseInternalBreadcrumbsOptions = {
+  /**
+   * The path of the currently active item. This should be a path
+   * relative to the repo (excluding the repo name), matching the item's href
+   * as it is defined in the sidebar configuration object.
+   */
+  activePath: string
+
+  /**
+   * The name of the related github repo
+   */
+  repo: string
+
+  /**
+   * The site's root URL.
+   */
+  rootUrl?: string
+
+  /**
+   * The configuration object that describes the page hierarchy.
+   */
+  sidebarConfig?: InternalSidebarConfig
+}
+
+const findItem = (sidebarConfig: InternalSidebarConfig, activePath: string) => {
+  for (const section of sidebarConfig.sections) {
+    for (const item of section.items) {
+      if (item.href === activePath) {
+        return item
+      }
+    }
+  }
+}
+
+/**
+ * Returns a list of breadcrumbs based on the `activePath`
+ */
+export const useInternalBreadcrumbs = ({
+  activePath,
+  sidebarConfig,
+  repo,
+  rootUrl = "/",
+}: UseInternalBreadcrumbsOptions) =>
+  useMemo(() => {
+    const item = sidebarConfig && findItem(sidebarConfig, activePath)
+
+    const breadcrumbs = [
+      { href: rootUrl, name: "Home" },
+
+      // TODO: How do we get a "displayable" name?
+      { name: repo, href: `${rootUrl}/${repo}` },
+    ]
+
+    if (item) {
+      breadcrumbs.push({ name: item.label, href: `/${repo}/${item.href}` })
+    }
+
+    return breadcrumbs
+  }, [activePath, sidebarConfig, rootUrl, repo])


### PR DESCRIPTION
Adds working breadcrumbs to internal pages.

This uses the same `repoSchema` that the sidebar uses to determine the breadcrumb items to show. 

<img width="1328" alt="Screen Shot 2022-06-23 at 1 47 13 PM" src="https://user-images.githubusercontent.com/393220/175362557-0a19aef9-3364-4b18-8d3c-127c394d3663.png">
