### PR TITLE
Combine data for similar featured article/tutorial

### DIFF
--- a/app/component-data/Articles/index.tsx
+++ b/app/component-data/Articles/index.tsx
@@ -2,41 +2,19 @@ import { FeaturedArticleCardProps } from "~/ui/design-system/src/lib/Components/
 import { TutorialCardProps } from "~/ui/design-system/src/lib/Components/TutorialCard"
 import CodeIcon from "~/ui/design-system/images/content/code.svg"
 
-const introToFlowBlockchainArticle: FeaturedArticleCardProps = {
-  heading: "Introduction to Flow blockchain: Part 1",
-  tags: ["protocol", "network"],
-  description: `When Dapper Labs built Crypto Kitties we learned a lot.
-    Most importantly, we realized that the technology at the time was not ready for this kind of application.
-    Being the visionaries we are, we set to build a better tech for what we plan to do.
-    We set to build what is now Flow blockchain.`,
-  link: "https://jan-bernatik.medium.com/introduction-to-flow-blockchain-7532977c8af8",
-  ctaText: "View Article",
-}
-
-const getTheFlowDownArticle: FeaturedArticleCardProps = {
-  heading: "Get the Flow Down",
-  tags: ["resource-list", "community"],
-  description: `
-  Get the Flow Down is a curated collection of the best Flow blockchain tools, tutorials, 
-  articles and more!
-  `,
-  link: "https://jan-bernatik.medium.com/introduction-to-flow-blockchain-7532977c8af8",
-  ctaText: "View List",
-}
-
-const redSquirrelGetStartedArticle: FeaturedArticleCardProps = {
+export const redSquirrelGetStartedArticle: FeaturedArticleCardProps = {
   heading: "Getting started on Flow by RedSquirrel",
   tags: ["tutorial", "nft", "beginner"],
   description: `
   Deploy a Cadence smart contract to a local emulator and interact with it as soon as possible!
-  I recently got the opportunity to help build a Non-Fungible Token using the Flow Blockchain. 
-  This was a whole new blockchain for me! Getting up and running with a new technology is always a 
+  I recently got the opportunity to help build a Non-Fungible Token using the Flow Blockchain.
+  This was a whole new blockchain for me! Getting up and running with a new technology is always a
   challenge, and I find that sometimes figuring out where to start is the hardest part.`,
   link: "https://medium.com/redsquirrel-tech/getting-started-with-the-flow-blockchain-31bfab956a96",
   ctaText: "View Article",
 }
 
-const organizingCadenceTutorial: TutorialCardProps = {
+export const organizingCadenceTutorial: TutorialCardProps = {
   heading: "How to organize Cadence projects",
   tags: ["protocol", "network"],
   description: `How you organize the files for your project in your Github repo by Joshua Hannan - a senior smart contract engineer at Flow.`,
@@ -49,30 +27,23 @@ const organizingCadenceTutorial: TutorialCardProps = {
   // }
 }
 
-const introToFlowBlockchainTutorial: TutorialCardProps = {
+export const introToFlow: TutorialCardProps & FeaturedArticleCardProps = {
   heading: "Introduction to Flow blockchain",
   tags: ["protocol", "network"],
   description: `When Dapper Labs built Crypto Kitties we learned a lot.
     Most importantly, we realized that the technology at the time was not ready for this kind of application.
     Being the visionaries we are, we set to build a better tech for what we plan to do.
     We set to build what is now Flow blockchain.`,
-  link: "https://joshuahannan.medium.com/how-i-organize-my-cadence-projects-75b811b700d9",
+  link: "https://jan-bernatik.medium.com/introduction-to-flow-blockchain-7532977c8af8",
+  ctaText: "View Article",
   imageUri: "https://miro.medium.com/max/1400/1*WXAWBMemgaBaHvO-oXDrEA.png",
 }
 
-const getTheFlowDownTutorial: TutorialCardProps = {
+export const getTheFlowDown: TutorialCardProps & FeaturedArticleCardProps = {
   heading: "Get the Flow Down",
-  tags: ["resource-list"],
+  tags: ["resource-list", "community"],
   description: `Get the Flow Down is a curated collection of the best Flow blockchain tools, tutorials, articles and more!`,
   link: "https://jan-bernatik.medium.com/introduction-to-flow-blockchain-7532977c8af8",
+  ctaText: "View List",
   imageUri: CodeIcon,
-}
-
-export {
-  introToFlowBlockchainArticle,
-  getTheFlowDownArticle,
-  redSquirrelGetStartedArticle,
-  organizingCadenceTutorial,
-  introToFlowBlockchainTutorial,
-  getTheFlowDownTutorial,
 }

--- a/app/routes/getting-started/data.tsx
+++ b/app/routes/getting-started/data.tsx
@@ -23,8 +23,8 @@ import {
   eventIndexingTool,
 } from "../../component-data/Tools"
 import {
-  introToFlowBlockchainArticle,
-  getTheFlowDownArticle,
+  introToFlow,
+  getTheFlowDown,
   redSquirrelGetStartedArticle,
 } from "../../component-data/Articles"
 import { FeaturedArticleCardProps } from "~/ui/design-system/src/lib/Components/FeaturedArticleCard"
@@ -34,7 +34,7 @@ const landingHeaderItems: LandingHeaderProps = {
   buttonText: "View Course",
   buttonUrl: "https://academy.ecdao.org/",
   callout: "Cadence Bootcamps",
-  description: `Learn everything about the Flow Blockchain and the Cadence smart contract programming language with Emerald Academy -  
+  description: `Learn everything about the Flow Blockchain and the Cadence smart contract programming language with Emerald Academy -
     a Flow partner for open source educational content.`,
   title: "Getting Started",
   imageSrc: "https://academy.ecdao.org/thumb-beginner-cadence.png",
@@ -200,11 +200,7 @@ const recentArticleItems: [
   FeaturedArticleCardProps,
   FeaturedArticleCardProps,
   FeaturedArticleCardProps
-] = [
-  introToFlowBlockchainArticle,
-  redSquirrelGetStartedArticle,
-  getTheFlowDownArticle,
-]
+] = [introToFlow, redSquirrelGetStartedArticle, getTheFlowDown]
 
 const recentToolItems: [ToolCardProps, ToolCardProps, ToolCardProps] = [
   overflowTool,

--- a/app/routes/learn/data.ts
+++ b/app/routes/learn/data.ts
@@ -2,15 +2,15 @@ import { TutorialCardProps } from "~/ui/design-system/src/lib/Components/Tutoria
 import { LargeVideoCardProps } from "~/ui/design-system/src/lib/Components/VideoCard/LargeVideoCard"
 import { SmallVideoCardProps } from "~/ui/design-system/src/lib/Components/VideoCard/SmallVideoCard"
 import {
-  getTheFlowDownTutorial,
+  getTheFlowDown,
   organizingCadenceTutorial,
-  introToFlowBlockchainTutorial,
+  introToFlow,
 } from "../../component-data/Articles"
 
 const cadenceTutorials: TutorialCardProps[] = [
-  getTheFlowDownTutorial,
+  getTheFlowDown,
   organizingCadenceTutorial,
-  introToFlowBlockchainTutorial,
+  introToFlow,
   {
     heading: "This Title Is A Two Liner",
     tags: ["TODO", "Tool", "Intermediate"],


### PR DESCRIPTION
We ultimately decided that actually combining the `FeaturedArticleCard` and the `TutorialCard` wasn't worth the extra complexity it added, because the components do render sufficiently different (different text sizes, image locations, etc).

But the real problem was that the data had to be specified twice. So by specifying them as a union of the underlying types  we can avoid doing that, so long as the props align (which they do). 