### PR TITLE
Only scroll on pagination of tutorial cards if necessary

### DIFF
--- a/app/ui/design-system/src/lib/Components/TutorialCard/PaginatedTutorialCardList.tsx
+++ b/app/ui/design-system/src/lib/Components/TutorialCard/PaginatedTutorialCardList.tsx
@@ -25,7 +25,7 @@ export const PaginatedTutorialCardList = ({
   tutorials,
   scrollOnPaginate = true,
 }: PaginatedTutorialCardListProps) => {
-  const topRef = useRef<HTMLDivElement>()
+  const scrollRef = useRef<HTMLAnchorElement>(null)
   const [page, setPage] = useState(1)
 
   // Whenever the page changes we want to scroll to the top of the list -- but
@@ -43,23 +43,24 @@ export const PaginatedTutorialCardList = ({
   }, [listId])
 
   useLayoutEffect(() => {
-    if (resetScroll > 0 && scrollOnPaginate) {
-      // We don't want to scroll on the initial render.
-      topRef.current?.scrollIntoView({ behavior: "smooth" })
+    if (!scrollRef.current || resetScroll === 0 || !scrollOnPaginate) {
+      return
     }
+
+    scrollRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" })
   }, [resetScroll, scrollOnPaginate])
 
   return (
     <div className={className}>
-      <div
-        className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-4 md:gap-6"
-        // @ts-expect-error please fix
-        ref={topRef}
-      >
+      <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-4 md:gap-6">
         {tutorials
           .slice((page - 1) * pageSize, page * pageSize)
           .map((tutorialProps, index) => (
-            <TutorialCard key={index} {...tutorialProps} />
+            <TutorialCard
+              key={index}
+              {...tutorialProps}
+              ref={index === 0 ? scrollRef : undefined}
+            />
           ))}
       </div>
       <Pagination

--- a/app/ui/design-system/src/lib/Components/TutorialCard/index.tsx
+++ b/app/ui/design-system/src/lib/Components/TutorialCard/index.tsx
@@ -1,7 +1,8 @@
 import clsx from "clsx"
+import { forwardRef } from "react"
 import { ReactComponent as CalendarIcon } from "../../../../images/action/date-calendar"
-import { ReactComponent as TutorialIcon } from "../../../../images/content/drafting-tools"
 import { ReactComponent as UserIcon } from "../../../../images/arrows/user"
+import { ReactComponent as TutorialIcon } from "../../../../images/content/drafting-tools"
 import { User } from "../../interfaces"
 import Tag from "../Tag"
 
@@ -17,71 +18,87 @@ export type TutorialCardProps = {
   author?: User
 }
 
-const TutorialCard = ({
-  className,
-  heading,
-  tags,
-  description,
-  lastUpdated,
-  level,
-  imageUri,
-  link,
-  author,
-}: TutorialCardProps) => {
-  const contentClasses = clsx('flex flex-col justify-between h-full"', {
-    "pt-8 px-4 pb-4 ": !imageUri,
-    "p-4": imageUri,
-  })
-  return (
-    <a
-      href={link}
-      className={clsx(
-        "flex flex-col overflow-hidden rounded-lg bg-white hover:shadow-2xl dark:bg-primary-gray-dark dark:hover:shadow-2xl-dark",
-        className
-      )}
-    >
-      {imageUri && (
-        <img src={imageUri} alt={heading} className="object-cov er h-[110px]" />
-      )}
-      <div className={contentClasses}>
-        <div>
-          <div className="text-lg font-bold md:text-xl">{heading}</div>
-          <div className="my-1 inline-flex flex-wrap">
-            {tags.map((tag) => (
-              <span className="my-1" key={tag}>
-                <Tag name={tag} />
-              </span>
-            ))}
+const TutorialCard = forwardRef<HTMLAnchorElement, TutorialCardProps>(
+  (
+    {
+      className,
+      heading,
+      tags,
+      description,
+      lastUpdated,
+      level,
+      imageUri,
+      link,
+      author,
+    },
+    ref
+  ) => {
+    const contentClasses = clsx('flex flex-col justify-between h-full"', {
+      "pt-8 px-4 pb-4 ": !imageUri,
+      "p-4": imageUri,
+    })
+    return (
+      <a
+        ref={ref}
+        href={link}
+        className={clsx(
+          "flex flex-col overflow-hidden rounded-lg bg-white hover:shadow-2xl dark:bg-primary-gray-dark dark:hover:shadow-2xl-dark",
+          className
+        )}
+      >
+        {imageUri && (
+          <img
+            src={imageUri}
+            alt={heading}
+            className="object-cov er h-[110px]"
+          />
+        )}
+        <div className={contentClasses}>
+          <div>
+            <div className="text-lg font-bold md:text-xl">{heading}</div>
+            <div className="my-1 inline-flex flex-wrap">
+              {tags.map((tag) => (
+                <span className="my-1" key={tag}>
+                  <Tag name={tag} />
+                </span>
+              ))}
+            </div>
+            <div className={imageUri ? "line-clamp-6" : "line-clamp-8"}>
+              {description}
+            </div>
           </div>
-          <div className={imageUri ? "line-clamp-6" : "line-clamp-8"}>
-            {description}
+          <div className="mt-6 flex justify-between text-xs text-primary-gray-300 dark:text-primary-gray-200">
+            {lastUpdated && (
+              <div className="flex items-center">
+                <CalendarIcon
+                  className="mr-1 scale-75"
+                  width="36"
+                  height="36"
+                />
+                Updated: {lastUpdated}
+              </div>
+            )}
+            {level && (
+              <div className="flex items-center">
+                <TutorialIcon className="mr-1" />
+                {level}
+              </div>
+            )}
+          </div>
+          <div className="text-xs text-primary-gray-300 dark:text-primary-gray-200">
+            {author && (
+              <div className="flex items-center">
+                <UserIcon className="mr-1 scale-75" />
+                {author.name}
+              </div>
+            )}
           </div>
         </div>
-        <div className="mt-6 flex justify-between text-xs text-primary-gray-300 dark:text-primary-gray-200">
-          {lastUpdated && (
-            <div className="flex items-center">
-              <CalendarIcon className="mr-1 scale-75" width="36" height="36" />
-              Updated: {lastUpdated}
-            </div>
-          )}
-          {level && (
-            <div className="flex items-center">
-              <TutorialIcon className="mr-1" />
-              {level}
-            </div>
-          )}
-        </div>
-        <div className="text-xs text-primary-gray-300 dark:text-primary-gray-200">
-          {author && (
-            <div className="flex items-center">
-              <UserIcon className="mr-1 scale-75" />
-              {author.name}
-            </div>
-          )}
-        </div>
-      </div>
-    </a>
-  )
-}
+      </a>
+    )
+  }
+)
+
+TutorialCard.displayName = "TutorialCard"
 
 export default TutorialCard


### PR DESCRIPTION
This should reduce some of the scrolling behavior for the paginated tutorial cards. They should now only scroll when the first card in the list is not visible in the viewport. So on mobile we should see the same behavior as before, but on desktop we won't scroll down when the first card is in the middle of the viewport.   

@srinjoyc let me know what you think about this behavior.  A further option if this is still not ideal would be to check if _any_ part of the card (or even the whole collection) is visible, and not scroll in those cases. 

#299