### PR TITLE
For consideration: enable Typescript noUncheckedIndexedAccess option

### DIFF
--- a/app/cms/utils/generate-toc.test.ts
+++ b/app/cms/utils/generate-toc.test.ts
@@ -76,7 +76,7 @@ test(`backticks`, () => {
 bar
   `
 
-  expect(markdownToToc(subject)![0].title).toBe(
+  expect(markdownToToc(subject)![0]!.title).toBe(
     `Avoid using AuthAccount as a function parameter`
   )
 })

--- a/app/gtags.client.ts
+++ b/app/gtags.client.ts
@@ -29,7 +29,7 @@ export const pageview = (url: string, trackingId: string) => {
  * https://developers.google.com/analytics/devguides/collection/gtagjs/events
  */
 export const event = ({
-  action,
+  action = "unknown",
   category,
   label,
   value,

--- a/app/routes/poll-discourse.tsx
+++ b/app/routes/poll-discourse.tsx
@@ -85,7 +85,8 @@ export default function () {
         {discourseData.latestTopics.map((t) => (
           <li id="user-content-fn-1" key={t.forumLink}>
             Post: {t.forumLink} - {t.heading} - {t.lastUpdatedDate} -{" "}
-            {t.numComments} - {t.participants[0].name}
+            {t.numComments}
+            {t.participants[0] ? ` - ${t.participants![0].name}` : ""}
           </li>
         ))}
       </div>

--- a/app/ui/design-system/src/lib/Components/EventCard/index.tsx
+++ b/app/ui/design-system/src/lib/Components/EventCard/index.tsx
@@ -7,7 +7,7 @@ export type EventCardProps = {
   onClick?: () => void
   className?: string
   ctaText?: string
-  description: string
+  description?: string
   eventDate: string
   href: string
   imageAlt?: string

--- a/app/ui/design-system/src/lib/Components/NavigationBar/MenuContent.tsx
+++ b/app/ui/design-system/src/lib/Components/NavigationBar/MenuContent.tsx
@@ -42,25 +42,24 @@ export function MenuContent({
           <MenuContentGrid hasCards={hasCards} isTabContent={isTabContent}>
             <SectionHeading
               className="col-span-full mb-2"
-              title={sections[0].title}
-              icon={sections[0].icon}
+              title={sections[0]!.title}
+              icon={sections[0]!.icon}
             />
-            {sections[0].subSections &&
-              sections[0].subSections.map((subsection, index) => (
-                <SubsectionLink
-                  key={index}
-                  href={subsection.href}
-                  title={subsection.title}
-                />
-              ))}
+            {sections[0]?.subSections?.map((subsection, index) => (
+              <SubsectionLink
+                key={index}
+                href={subsection.href}
+                title={subsection.title}
+              />
+            ))}
           </MenuContentGrid>
-          {sections[0].links && (
+          {sections[0]!.links && (
             <MenuContentGrid
               className="mt-2 border-t"
               hasCards={hasCards}
               isTabContent={isTabContent}
             >
-              <SectionLinkList links={sections[0].links} />
+              <SectionLinkList links={sections[0]!.links} />
             </MenuContentGrid>
           )}
         </div>

--- a/app/ui/design-system/src/lib/Components/Search/Panel.tsx
+++ b/app/ui/design-system/src/lib/Components/Search/Panel.tsx
@@ -48,7 +48,7 @@ export function Panel({
               {items.map((item: HitType, index: number) => {
                 const itemProps = autocomplete.getItemProps({
                   item,
-                  source: collection.source,
+                  source: collection!.source, // defined because `items` is defined
                 })
                 const selected = itemProps["aria-selected"]
                 return (

--- a/app/ui/design-system/src/lib/Components/UpcomingEvents/index.tsx
+++ b/app/ui/design-system/src/lib/Components/UpcomingEvents/index.tsx
@@ -8,7 +8,7 @@ import TabMenu from "../TabMenu"
 
 export type UpcomingEventsProps = {
   goToCommunityHref: string
-  events: EventCardProps[]
+  events: [EventCardProps, ...EventCardProps[]]
   headerLink?: string
 }
 
@@ -21,7 +21,7 @@ export function UpcomingEvents({
 }: UpcomingEventsProps) {
   const [tabIndex, setTabIndex] = useState(0)
   const [selectedEventTitle, setSelectedEventTitle] = useState<string | null>(
-    events[0].title
+    events[0]?.title ?? null
   )
   const onTabChange = (filterIndex: number) => {
     setSelectedEventTitle(null)
@@ -52,7 +52,7 @@ export function UpcomingEvents({
       />
       <div className="py-6">
         <div className="hidden md:block">
-          <EventCard {...primaryEvent} className="mb-4" />
+          {primaryEvent && <EventCard {...primaryEvent} className="mb-4" />}
           <ul className="hidden list-none flex-row gap-6 overflow-x-auto md:flex">
             {filteredEvents.map((event: EventCardProps, index: number) => (
               <li key={index}>

--- a/app/ui/design-system/src/lib/Pages/NetworkDetailPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/NetworkDetailPage/index.tsx
@@ -26,7 +26,7 @@ export type NetworkDetailPageProps = {
 export const getNetworkNameFromParam = (param: string) =>
   param
     .split("-")
-    .map((name) => name[0].toUpperCase() + name.slice(1))
+    .map((name) => name.slice(0, 1).toUpperCase() + name.slice(1))
     .join(" ")
 
 const NetworkDetailPage = ({
@@ -59,11 +59,11 @@ const NetworkDetailPage = ({
           </div>
           <TabMenu tabs={tabs} onTabChange={setSelectedNetworkIndex} centered />
           <div className="text-h3 md:text-h1 mt-16 mb-14 pl-4 md:text-center md:text-5xl">
-            {currentNetwork.name}
+            {currentNetwork?.name}
           </div>
           <NetworkDetailsCard
             status={
-              currentNetwork.status === "operational"
+              currentNetwork?.status === "operational"
                 ? "Healthy"
                 : "Under Maintenance"
             }
@@ -83,7 +83,7 @@ const NetworkDetailPage = ({
               Upcoming Spork
             </HeaderWithLink>
             <SporksCard
-              heading={currentNetwork.name}
+              heading={currentNetwork?.name || ""}
               timestamp={endOfWeek(new Date())}
               sporkMetadata={{
                 accessNode: "access-001.mainnet15.nodes.onflow.org:9000",
@@ -113,7 +113,7 @@ const NetworkDetailPage = ({
               {[1, 2, 3, 4].map((index) => (
                 <div className="divided-item-hover" key={index}>
                   <SporksCard
-                    heading={currentNetwork.name}
+                    heading={currentNetwork?.name || ""}
                     timestamp={endOfWeek(new Date())}
                     sporkMetadata={{
                       accessNode: "access-001.mainnet15.nodes.onflow.org:9000",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "noEmit": true,
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "module": "esnext"
+    "module": "esnext",
+    "noUncheckedIndexedAccess": true
   },
   "exclude": ["app/ui/design-system/**/*.stories.tsx"]
 }


### PR DESCRIPTION
Proposing we enabled `noUncheckedIndexedAccess` in our `tsconfig.json`. I've found this can catch a lot of bugs. I"m not entirely sure why this isn't the default these days (maybe for backwards compatibility?)