### PR TITLE
Add MemoryRouter to Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,6 @@
 import { useGlobals, useParameter, useEffect } from "@storybook/addons"
 import clsx from "clsx"
+import { MemoryRouter } from "react-router"
 import "../app/main.css"
 import tailwindConfig from "../tailwind.config"
 
@@ -88,4 +89,16 @@ const withDarkMode = (Story, context) => {
   return <Story {...context} />
 }
 
-export const decorators = [withDarkMode]
+const withRouter = (Story, context) => {
+  if (context.parameters.router?.disable === true) {
+    return <Story {...context} />
+  }
+
+  return (
+    <MemoryRouter>
+      <Story {...context} />
+    </MemoryRouter>
+  )
+}
+
+export const decorators = [withDarkMode, withRouter]

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/InternalSidebar.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/InternalSidebar.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, Story } from "@storybook/react"
-import { MemoryRouter } from "react-router"
 import { InternalSidebar, InternalSidebarProps, TEMP_SIDEBAR_CONFIG } from "."
 
 export default {
@@ -8,9 +7,7 @@ export default {
 } as Meta
 
 const Template: Story<InternalSidebarProps> = (args) => (
-  <MemoryRouter>
-    <InternalSidebar {...args} />
-  </MemoryRouter>
+  <InternalSidebar {...args} />
 )
 
 export const Default = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/Link/Link.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/Link/Link.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, Story } from "@storybook/react"
-import { MemoryRouter } from "react-router"
 import { Link, LinkProps } from "."
 
 export default {
@@ -10,16 +9,13 @@ export default {
   },
 } as Meta
 
-const Template: Story<LinkProps> = (args) => (
-  <MemoryRouter>
-    <Link {...args} />
-  </MemoryRouter>
-)
+const Template: Story<LinkProps> = (args) => <Link {...args} />
 
 export const ExternalLink = Template.bind({})
 ExternalLink.args = {
   href: "http://www.example.com",
   children: "External Link",
+  isExternal: true,
 }
 
 export const InternalLink = Template.bind({})

--- a/app/ui/design-system/src/lib/Pages/InternalPage/InternalPage.stories.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/InternalPage.stories.tsx
@@ -7,6 +7,9 @@ export default {
   title: "Pages/InternalPage",
   parameters: {
     layout: "padded",
+    router: {
+      disable: true,
+    },
   },
 } as Meta
 

--- a/app/ui/design-system/src/lib/Pages/ToolsPage/ToolsPage.stories.tsx
+++ b/app/ui/design-system/src/lib/Pages/ToolsPage/ToolsPage.stories.tsx
@@ -33,26 +33,28 @@ const args = {
     lastCommit: "22/3",
     lastRelease: "207",
   }),
-  contentNavigationItems: [
-    {
-      title: "Learn",
-      text: "Lorem ipsum dolor sit amet proin gravida lorem ipsum",
-      link: "#",
-      icon: "learn",
-    },
-    {
-      title: "Tools",
-      text: "Lorem ipsum dolor sit amet proin gravida lorem ipsum",
-      link: "#",
-      icon: "tools",
-    },
-    {
-      title: "Concepts",
-      text: "Lorem ipsum dolor sit amet proin gravida lorem ipsum",
-      link: "#",
-      icon: "concepts",
-    },
-  ],
+  contentNavigationListItems: {
+    contentNavigationItems: [
+      {
+        title: "Learn",
+        text: "Lorem ipsum dolor sit amet proin gravida lorem ipsum",
+        link: "#",
+        icon: "learn",
+      },
+      {
+        title: "Tools",
+        text: "Lorem ipsum dolor sit amet proin gravida lorem ipsum",
+        link: "#",
+        icon: "tools",
+      },
+      {
+        title: "Concepts",
+        text: "Lorem ipsum dolor sit amet proin gravida lorem ipsum",
+        link: "#",
+        icon: "concepts",
+      },
+    ],
+  },
   apisAndServices: Array(6).fill({
     heading: "Such title, much heading",
     tags: ["Tool"],
@@ -73,7 +75,8 @@ const args = {
       "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/A_black_image.jpg/2560px-A_black_image.jpg",
     link: "/tutorials",
   }),
-}
+} as ToolsPageProps
+
 export const Default = Template.bind({})
 Default.args = args
 


### PR DESCRIPTION
This wraps all Storybook stories in a `<MemoryRouter />` so that if a routing component is used it doesn't throw an error. This is currently breaking stories for the following components:

- `Flips`
- `TabMenu`
- `ToolsAndConcepts`
- `UpcomingEvents`
- `CommunityPage`
- `HomePage`
- `NetworkDetailPage`


Also added an option to disable this as-needed (see `InternalPage.stories.tsx` for an example):

```js
export default {
  component: Component,
  parameters: {
    router: {
      disable: true,
    },
  },
}
```

I considered making this opt-in instead of opt-out, but I don't think including it when it's not needed will cause any issue. Also as we build more complex components and make changes to core underlying components it's not always going to be super-obvious where this is going to be needed. But if there's a preference to reverse this behavior and make it opt-in I'm happy to adjust that here. 