### PR TITLE
Add repo switcher to internal pages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
     "jsx-a11y/anchor-has-content": "off",
     "jsx-a11y/anchor-is-valid": "off",
     "jsx-a11y/alt-text": "off",
-    "jsx-a11y/iframe-has-title": "off"
+    "jsx-a11y/iframe-has-title": "off",
+    "@typescript-eslint/no-unused-vars": "warn"
   },
   "env": {
     "browser": true,

--- a/app/routes/$repo.tsx
+++ b/app/routes/$repo.tsx
@@ -7,8 +7,9 @@ import {
   useMatches,
 } from "@remix-run/react"
 import invariant from "tiny-invariant"
-import { ContentSpec, getContentSpec } from "~/constants/repos"
+import { ContentName, ContentSpec, getContentSpec } from "~/constants/repos"
 import { ErrorPage } from "~/ui/design-system/src/lib/Components/ErrorPage"
+import { ToolName } from "~/ui/design-system/src/lib/Components/Internal/tools"
 import { temporarilyRedirectToComingSoon } from "~/utils/features"
 import { InternalPage } from "../ui/design-system/src/lib/Pages/InternalPage"
 
@@ -49,10 +50,37 @@ export default function Repo() {
       contentDisplayName={content.displayName}
       contentPath={content.contentName}
       sidebarConfig={content.schema?.sidebar}
+      internalSidebarMenu={{
+        selectedTool: contentToolMap[content.contentName],
+        toolLinks: toolLinks,
+      }}
     >
       <Outlet />
     </InternalPage>
   )
+}
+
+const toolContentMap: Record<ToolName, ContentName> = {
+  cadence: "cadence",
+  cli: "flow-cli",
+  emulator: "flow-emulator",
+  fcl: "fcl-js",
+  testing: "flow-js-testing",
+  vscode: "vscode-extension",
+}
+
+const toolLinks: Record<ToolName, string> = { ...toolContentMap }
+for (let [key, value] of Object.entries(toolLinks)) {
+  toolLinks[key as ToolName] = `/${value}`
+}
+
+const contentToolMap: Record<string, ToolName> = {
+  cadence: "cadence",
+  "flow-cli": "cli",
+  "flow-emulator": "emulator",
+  "fcl-js": "fcl",
+  "flow-js-testing": "testing",
+  "vscode-extension": "vscode",
 }
 
 export function CatchBoundary() {

--- a/app/routes/$repo/$.tsx
+++ b/app/routes/$repo/$.tsx
@@ -55,7 +55,7 @@ export default function RepoDocument() {
   return (
     <div className="pl-[55px]">
       <div className="grid grid-cols-5">
-        <div className="col-span-4">
+        <div className="col-span-4 pt-8">
           <MDXContent />
         </div>
         <div className="pt-[55px]">

--- a/app/routes/$repo/$.tsx
+++ b/app/routes/$repo/$.tsx
@@ -40,7 +40,7 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   }
 }
 
-export default function () {
+export default function RepoDocument() {
   const data = useLoaderData()
   const location = useLocation()
   const { code, frontmatter, toc } = data.page

--- a/app/routes/$repo/index.tsx
+++ b/app/routes/$repo/index.tsx
@@ -1,0 +1,4 @@
+import RepoDocument, { loader, CatchBoundary } from "./$"
+
+export default RepoDocument
+export { loader, CatchBoundary }

--- a/app/ui/design-system/src/lib/Components/Internal/tools.ts
+++ b/app/ui/design-system/src/lib/Components/Internal/tools.ts
@@ -7,8 +7,6 @@ import { ReactComponent as EmulatorIcon } from "../../../../images/tools/tool-em
 import { ReactComponent as EmulatorGradientIcon } from "../../../../images/tools/tool-emulator-gradient"
 import { ReactComponent as FclIcon } from "../../../../images/tools/tool-fcl"
 import { ReactComponent as FclGradientIcon } from "../../../../images/tools/tool-fcl-gradient"
-import { ReactComponent as PortIcon } from "../../../../images/tools/tool-port"
-import { ReactComponent as PortGradientIcon } from "../../../../images/tools/tool-port-gradient"
 import { ReactComponent as TestingIcon } from "../../../../images/tools/tool-testing"
 import { ReactComponent as TestingGradientIcon } from "../../../../images/tools/tool-testing-gradient"
 import { ReactComponent as VsCodeIcon } from "../../../../images/tools/tool-vscode"
@@ -19,7 +17,6 @@ import { ReactComponent as VsCodeGradientIcon } from "../../../../images/tools/t
 export type ToolName =
   | "emulator"
   | "vscode"
-  | "port"
   | "cli"
   | "testing"
   | "fcl"
@@ -44,12 +41,6 @@ export const TOOLS: Record<ToolName, Tool> = {
     icon: VsCodeIcon,
     iconLanding: CadenceLandingIcon,
     gradientIcon: VsCodeGradientIcon,
-  },
-  port: {
-    name: "Port",
-    icon: PortIcon,
-    iconLanding: CadenceLandingIcon,
-    gradientIcon: PortGradientIcon,
   },
   cli: {
     name: "CLI",

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
@@ -54,9 +54,20 @@ export const TEMP_SIDEBAR_CONFIG: InternalSidebarConfig = {
   ],
 }
 
+export function InternalSidebarContainer(props: {
+  children?: React.ReactNode
+}) {
+  return (
+    <div
+      className="mb-8 w-full min-w-min flex-1 shrink-0 bg-gray-100 bg-opacity-80 p-8 dark:bg-primary-gray-dark md:mb-0 md:w-80"
+      {...props}
+    />
+  )
+}
+
 export function InternalSidebar({ config }: InternalSidebarProps) {
   return (
-    <div className="mb-8 w-full min-w-min shrink-0 bg-gray-100 bg-opacity-80 p-8 dark:bg-primary-gray-dark md:mb-0 md:w-80">
+    <>
       {config.sections.map((section) => (
         <div
           className="border-b-1 mb-2 border-b border-b-gray-300 py-4 last:border-b-0 dark:border-b-gray-700"
@@ -86,6 +97,6 @@ export function InternalSidebar({ config }: InternalSidebarProps) {
           </div>
         </div>
       ))}
-    </div>
+    </>
   )
 }

--- a/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
@@ -157,7 +157,8 @@ export function InternalSidebarMenu({
               style={{ top: y || 0, left: x || 0 }}
             >
               <DropdownTransition>
-                <Popover.Panel className="relative mr-2 min-w-[17rem] max-w-[34rem] overflow-y-auto rounded-lg bg-white px-4 py-2 shadow-2xl dark:bg-primary-gray-dark dark:shadow-2xl-dark dark:hover:shadow-2xl-dark dark:hover:shadow-2xl-dark md:px-6 md:py-4">
+                {/* fyi max-w-[34rem] is the intended full width here, using max-w-[18rem] since some entries are temporarily disabled */}
+                <Popover.Panel className="relative mr-2 min-w-[17rem] max-w-[18rem] overflow-y-auto rounded-lg bg-white px-4 py-2 shadow-2xl dark:bg-primary-gray-dark dark:shadow-2xl-dark dark:hover:shadow-2xl-dark dark:hover:shadow-2xl-dark md:px-6 md:py-4">
                   {({ close }) =>
                     SIDEBAR_SECTION_GROUPS.map((group, index) => (
                       <SidebarSectionGroup

--- a/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
@@ -15,14 +15,10 @@ export type Version = {
 
 type SectionGroup = { name: string; sections: ToolName[] }
 
-export type InternalSidebarMenuProps = {
-  selectedTool: ToolName
-}
-
 const SIDEBAR_SECTION_GROUPS: SectionGroup[] = [
   {
     name: "Switch tool",
-    sections: ["emulator", "vscode", "port", "cli", "testing"],
+    sections: ["emulator", "vscode", "cli", "testing"],
   },
   {
     name: "Concepts",
@@ -30,7 +26,13 @@ const SIDEBAR_SECTION_GROUPS: SectionGroup[] = [
   },
 ]
 
-function Group({ group }: { group: SectionGroup }) {
+function Group({
+  group,
+  toolLinks,
+}: {
+  group: SectionGroup
+  toolLinks: ToolLinkMap
+}) {
   return (
     <>
       {group.sections.map((section: ToolName) => {
@@ -42,7 +44,7 @@ function Group({ group }: { group: SectionGroup }) {
             className="border-b border-b-primary-gray-100 last:border-none md:border-none md:p-0"
           >
             <a
-              href="#"
+              href={toolLinks[section]}
               className={clsx(
                 "group flex items-center px-1 py-2 text-center text-sm hover:bg-primary-gray-100/50 dark:bg-black hover:dark:bg-primary-gray-400/5 md:h-[7.5rem] md:w-[7rem] md:flex-col md:rounded-lg md:px-4 md:py-5 md:shadow-2xl dark:md:shadow-2xl-dark"
               )}
@@ -70,10 +72,12 @@ function SidebarSectionGroup({
   group,
   index,
   close,
+  toolLinks,
 }: {
   group: SectionGroup
   index: number
   close: () => void
+  toolLinks: ToolLinkMap
 }) {
   return (
     <div className="mb-2 md:mb-6 md:divide-y md:divide-solid dark:md:divide-primary-gray-300">
@@ -92,14 +96,22 @@ function SidebarSectionGroup({
         )}
       </div>
       <div className="flex flex-col py-4 md:flex-row md:flex-wrap md:gap-4 md:py-6">
-        <Group group={group} />
+        <Group group={group} toolLinks={toolLinks} />
       </div>
     </div>
   )
 }
 
+type ToolLinkMap = Record<ToolName, string>
+
+export type InternalSidebarMenuProps = {
+  selectedTool: ToolName
+  toolLinks: ToolLinkMap
+}
+
 export function InternalSidebarMenu({
   selectedTool,
+  toolLinks,
 }: InternalSidebarMenuProps) {
   const arrowRef = useRef(null)
   const {
@@ -146,6 +158,7 @@ export function InternalSidebarMenu({
                         index={index}
                         key={index}
                         close={close}
+                        toolLinks={toolLinks}
                       />
                     ))
                   }

--- a/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
@@ -18,7 +18,14 @@ type SectionGroup = { name: string; sections: ToolName[] }
 const SIDEBAR_SECTION_GROUPS: SectionGroup[] = [
   {
     name: "Switch tool",
-    sections: ["emulator", "vscode", "cli", "testing"],
+    sections: [
+      // temporarily disabled
+      // "emulator",
+      "vscode",
+      // temporarily disabled
+      // "cli",
+      "testing",
+    ],
   },
   {
     name: "Concepts",

--- a/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
@@ -133,7 +133,7 @@ export function InternalSidebarMenu({
               </div>
             </Popover.Button>
             <div
-              className="absolute mt-8 w-full md:min-w-[15rem]"
+              className="absolute z-10 mt-8 w-screen px-4 md:min-w-[15rem]"
               ref={floating}
               style={{ top: y || 0, left: x || 0 }}
             >

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -1,4 +1,8 @@
-import { InternalSidebar } from "../../Components/InternalSidebar"
+import {
+  InternalSidebar,
+  InternalSidebarContainer,
+} from "../../Components/InternalSidebar"
+import { InternalSidebarMenu } from "../../Components/InternalSidebarMenu"
 import { InternalSubnav } from "../../Components/InternalSubnav"
 import {
   useInternalBreadcrumbs,
@@ -26,9 +30,16 @@ export function InternalPage({
 
   return (
     <div className="flex flex-col">
-      <InternalSubnav items={breadcrumbs} className="sticky top-0 z-10" />
+      <InternalSubnav items={breadcrumbs} className="sticky top-0 z-20" />
       <div className="flex flex-1 flex-row overflow-auto">
-        {sidebarConfig && <InternalSidebar config={sidebarConfig} />}
+        {sidebarConfig && (
+          <div className="flex flex-col">
+            <InternalSidebarContainer>
+              <InternalSidebarMenu selectedTool="cadence" />
+              <InternalSidebar config={sidebarConfig} />
+            </InternalSidebarContainer>
+          </div>
+        )}
         <div className="flex-1 overflow-auto">{children}</div>
       </div>
     </div>

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -2,7 +2,10 @@ import {
   InternalSidebar,
   InternalSidebarContainer,
 } from "../../Components/InternalSidebar"
-import { InternalSidebarMenu } from "../../Components/InternalSidebarMenu"
+import {
+  InternalSidebarMenu,
+  InternalSidebarMenuProps,
+} from "../../Components/InternalSidebarMenu"
 import { InternalSubnav } from "../../Components/InternalSubnav"
 import {
   useInternalBreadcrumbs,
@@ -10,7 +13,9 @@ import {
 } from "./useInternalBreadcrumbs"
 
 export type InternalPageProps = React.PropsWithChildren<{}> &
-  UseInternalBreadcrumbsOptions
+  UseInternalBreadcrumbsOptions & {
+    internalSidebarMenu: InternalSidebarMenuProps
+  }
 
 export function InternalPage({
   activePath,
@@ -19,6 +24,7 @@ export function InternalPage({
   contentPath,
   rootUrl = "/",
   sidebarConfig,
+  internalSidebarMenu,
 }: InternalPageProps) {
   const breadcrumbs = useInternalBreadcrumbs({
     activePath,
@@ -31,11 +37,11 @@ export function InternalPage({
   return (
     <div className="flex flex-col">
       <InternalSubnav items={breadcrumbs} className="sticky top-0 z-20" />
-      <div className="flex flex-1 flex-row overflow-auto">
+      <div className="flex flex-1 flex-row">
         {sidebarConfig && (
           <div className="flex flex-col">
             <InternalSidebarContainer>
-              <InternalSidebarMenu selectedTool="cadence" />
+              <InternalSidebarMenu {...internalSidebarMenu} />
               <InternalSidebar config={sidebarConfig} />
             </InternalSidebarContainer>
           </div>


### PR DESCRIPTION
please note that i took the approach that worked with the existing `InternalSidebarMenu` implementation, it might make more sense to eventually change that component so that it doesn't have it's own concept of "ToolName" etc, but for now this was faster to implement.

additionally this loads index.md / index.mdx on paths like /cadence – i think it was working this way previously to some of my changes, but this change is relevant to #282 

Fixes #283 


<img width="1539" alt="Screen Shot 2022-06-24 at 1 18 25 PM" src="https://user-images.githubusercontent.com/921605/175661393-8f62b2d9-796b-4303-8881-a778515ba04a.png">
<img width="1900" alt="Screen Shot 2022-06-24 at 11 59 42 AM" src="https://user-images.githubusercontent.com/921605/175661399-1b4f9c7b-f207-4a48-9dd8-0642d5820c69.png">
<img width="1539" alt="Screen Shot 2022-06-24 at 1 19 10 PM" src="https://user-images.githubusercontent.com/921605/175661455-c8df25c9-2764-4b62-99c6-43bc9ed61e59.png">

