### PR TITLE
Add cadence landing page header

### DIFF
--- a/app/constants/repos/index.ts
+++ b/app/constants/repos/index.ts
@@ -1,13 +1,14 @@
+import { capitalCase } from "change-case"
+import { InternalLandingHeaderProps } from "../../ui/design-system/src/lib/Components/InternalLandingHeader"
 import cadence from "./presets/cadence.json"
+import dappDevelopment from "./presets/dapp-development.json"
 import fclJs from "./presets/fcl-js.json"
 import flowCli from "./presets/flow-cli.json"
 import kittyItems from "./presets/kitty-items.json"
 import vscodeExtension from "./presets/vscode-extension.json"
 import flowGoSdk from "./presets/flow-go-sdk.json"
 import flowJsTesting from "./presets/flow-js-testing.json"
-import dappDevelopment from "./presets/dapp-development.json"
 import { RepoSchema } from "./repo-schema"
-import { capitalCase } from "change-case"
 
 /* Repository names and Flow internal content names */
 const repositoryNames = [
@@ -52,6 +53,40 @@ export const displayNames: Partial<Record<ContentName, string>> = {
   "dapp-development": "DApp Development",
 }
 
+/**
+ * Custom headers that can optionally be applied per-content section and will
+ * be shown on the section's landing page.
+ */
+export const landingHeaders: Partial<
+  Record<ContentName, InternalLandingHeaderProps>
+> = {
+  cadence: {
+    toolName: "cadence",
+    description:
+      "Cadence is a resource-oriented programming language that introduces new features to smart contract programming that help developers ensure that their code is safe, secure, clear, and approachable. Some of these features are:",
+    headerCards: [
+      {
+        title: "Key reference",
+        tags: ["Tutorial"],
+        description: "Lorem ipsum about this link",
+        href: "/cadence/design-patterns",
+      },
+      {
+        title: "Key reference",
+        tags: ["Tutorial", "Cadence"],
+        description: "Lorem ipsum about this link",
+        href: "/cadence/anti-patterns",
+      },
+      {
+        title: "Key reference",
+        tags: ["Tutorial"],
+        description: "Lorem ipsum about this link",
+        href: "/cadence/migration-guide",
+      },
+    ],
+  },
+}
+
 type RepoName = typeof repositoryNames[number]
 type FlowContentName = typeof flowContentNames[number]
 export type ContentName = RepoName | FlowContentName
@@ -61,16 +96,18 @@ export type ContentSpec = {
   contentName: string
   displayName: string
   schema?: RepoSchema
+  landingHeader?: InternalLandingHeaderProps
 }
 
 export const contentSpecMap = [...repositoryNames, ...flowContentNames].reduce(
   (accum, name) => ({
     ...accum,
     [name]: {
-      repoName: repositoryNames.includes(name as RepoName) ? name : "flow",
+      repoName: isRepo(name) ? name : "flow",
       contentName: name,
       displayName: displayNames[name] || capitalCase(name),
       schema: schemas[name],
+      landingHeader: landingHeaders[name],
     },
   }),
   {} as Record<ContentName, ContentSpec>

--- a/app/routes/$repo.tsx
+++ b/app/routes/$repo.tsx
@@ -43,12 +43,14 @@ export default function Repo() {
   const { content } = useLoaderData<LoaderData>()
   const matches = useMatches()
   const [match] = matches.slice(-1)
+  const path = match.params["*"] || "index"
 
   return (
     <InternalPage
-      activePath={match.params["*"] || "index"}
+      activePath={path}
       contentDisplayName={content.displayName}
       contentPath={content.contentName}
+      header={path === "index" ? content.landingHeader : undefined}
       sidebarConfig={content.schema?.sidebar}
       internalSidebarMenu={{
         selectedTool: contentToolMap[content.contentName],

--- a/app/ui/design-system/src/lib/Components/InternalLandingHeader/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalLandingHeader/index.tsx
@@ -45,11 +45,8 @@ export function InternalLandingHeader({
             Getting Started
           </div>
           <div className="flex flex-col gap-10 md:flex-row">
-            {headerCards.map((headerCard) => (
-              <InternalLandingHeaderCard
-                key={headerCard.title}
-                {...headerCard}
-              />
+            {headerCards.map((headerCard, index) => (
+              <InternalLandingHeaderCard key={index} {...headerCard} />
             ))}
           </div>
         </div>

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -1,4 +1,8 @@
 import {
+  InternalLandingHeader,
+  InternalLandingHeaderProps,
+} from "../../Components/InternalLandingHeader"
+import {
   InternalSidebar,
   InternalSidebarContainer,
 } from "../../Components/InternalSidebar"
@@ -12,16 +16,18 @@ import {
   UseInternalBreadcrumbsOptions,
 } from "./useInternalBreadcrumbs"
 
-export type InternalPageProps = React.PropsWithChildren<{}> &
-  UseInternalBreadcrumbsOptions & {
-    internalSidebarMenu: InternalSidebarMenuProps
-  }
+export type InternalPageProps = React.PropsWithChildren<{
+  header?: InternalLandingHeaderProps
+  internalSidebarMenu: InternalSidebarMenuProps
+}> &
+  UseInternalBreadcrumbsOptions
 
 export function InternalPage({
   activePath,
   children,
   contentDisplayName,
   contentPath,
+  header,
   rootUrl = "/",
   sidebarConfig,
   internalSidebarMenu,
@@ -37,6 +43,7 @@ export function InternalPage({
   return (
     <div className="flex flex-col">
       <InternalSubnav items={breadcrumbs} className="sticky top-0 z-20" />
+      {header && <InternalLandingHeader {...header} />}
       <div className="flex flex-1 flex-row">
         {sidebarConfig && (
           <div className="flex flex-col">


### PR DESCRIPTION
Adds a header to the cadence landing page

<img width="1103" alt="Screen Shot 2022-06-24 at 3 26 17 PM" src="https://user-images.githubusercontent.com/393220/175653779-8dba0db4-7118-45ef-a360-7d60af0f47dd.png">

The props for this are specified by the same way the sidebar schema is. So this will make it simpler fi we want to allow the content authors to define/modify these headers. Seemed liked the best approach, but open to reworking if there are suggestions on how to better approach this.

---

Closes #304 