### PR TITLE
Remove NODE_ENV=development check since disabled pages are live

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+SENTRY_DSN=some_fake_dsn
+BOT_GITHUB_TOKEN=
+SESSION_SECRET=anything_works_here
+REDIS_URL="redis://:flow_docs@localhost:6379"
+REFRESH_CACHE_SECRET=really_whatever
+FORCE_REFRESH="true"
+INCOMPLETE_PAGE_BEHAVIOR="preview"

--- a/app/utils/features.ts
+++ b/app/utils/features.ts
@@ -4,9 +4,7 @@ import { redirect } from "@remix-run/node"
  * @see https://github.com/onflow/next-docs-v1/issues/260
  */
 export function temporarilyRedirectToComingSoon() {
-  const isPreview =
-    process.env.INCOMPLETE_PAGE_BEHAVIOR === "preview" || // allow envs like staging to preview incomplete pages
-    process.env.NODE_ENV === "development" // assume people want to see these pages in dev
+  const isPreview = process.env.INCOMPLETE_PAGE_BEHAVIOR === "preview" // allow envs like staging to preview incomplete pages
 
   if (!isPreview) {
     throw redirect(`/coming-soon`)


### PR DESCRIPTION
unclear why these are loading in production, please note that you may need to set `INCOMPLETE_PAGE_BEHAVIOR="preview"` in your .env if you unexpectedly are redirected to the "Coming soon" screen