### PR TITLE
Improve behavior of getRequiredEnvVarFromObj

### DIFF
--- a/app/cms/helpers.ts
+++ b/app/cms/helpers.ts
@@ -3,17 +3,15 @@ import type { getEnv } from "../env.server"
 function getRequiredEnvVarFromObj(
   obj: Record<string, string | undefined>,
   key: string,
-  // eslint-disable-next-line
-  devValue: string = `${key}-dev-value`
+  devValue?: string
 ) {
-  let value = devValue
   const envVal = obj[key]
   if (envVal) {
-    value = envVal
-  } else if (obj["NODE_ENV"] === "production") {
-    throw new Error(`${key} is a required env variable`)
+    return envVal
+  } else if (devValue != null && obj["NODE_ENV"] !== "production") {
+    return devValue
   }
-  return value
+  throw new Error(`${key} is a required env variable`)
 }
 
 function getRequiredServerEnvVar(key: string, devValue?: string) {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -62,7 +62,10 @@ export const loader: LoaderFunction = async ({ request }) => {
   const themeSession = await getThemeSession(request)
   return json<LoaderData>({
     theme: themeSession.getTheme(),
-    gaTrackingId: getRequiredServerEnvVar("GA_TRACKING_ID"),
+    gaTrackingId: getRequiredServerEnvVar(
+      "GA_TRACKING_ID",
+      "GA_TRACKING_ID-dev-value"
+    ),
   })
 }
 


### PR DESCRIPTION
instead of automatically providing an env var in dev for every api key, which doesn't always make sense, this can be done on an as-needed-basis