### PR TITLE
Add frontmatter title as h1, description as p

### DIFF
--- a/app/cms/utils/mdx.tsx
+++ b/app/cms/utils/mdx.tsx
@@ -286,7 +286,7 @@ function mapFromMdxPageToMdxListItem(page: MdxPage): MdxListItem {
 
 const isLinkExternal = (href?: string) => !!href?.match(/^(www|http)/i)
 
-function GetMdxComponents(theme: Theme | null) {
+function GetMdxComponents(theme: Theme, title: string | null) {
   return {
     a: (props: LinkProps & { href: string }) => {
       if (isLinkExternal(props.href)) {
@@ -333,16 +333,27 @@ function GetMdxComponents(theme: Theme | null) {
  * @returns the component
  */
 function getMdxComponent(page: MdxPage, theme: Theme | null) {
-  const { code } = page
+  const { code, frontmatter } = page
+  const Component = getMDXComponent(code, frontmatter)
 
-  const Component = getMDXComponent(code)
   // const headings = getHeadingsFromMdxComponent(Component);
   function MdxComponent({
     components,
     ...rest
   }: Parameters<typeof Component>["0"]) {
-    /* @ts-expect-error: Does not like the link tage type definition above */
-    return <Component components={GetMdxComponents(theme)} {...rest} />
+    return (
+      <>
+        <header>
+          <Heading type="h1" children={frontmatter.title} />
+          <p>{frontmatter.description}</p>
+        </header>
+        <Component
+          /* @ts-expect-error: Does not like the link tage type definition above */
+          components={GetMdxComponents(theme, frontmatter.title)}
+          {...rest}
+        />
+      </>
+    )
   }
   return MdxComponent
 }

--- a/app/cms/utils/mdx.tsx
+++ b/app/cms/utils/mdx.tsx
@@ -286,7 +286,7 @@ function mapFromMdxPageToMdxListItem(page: MdxPage): MdxListItem {
 
 const isLinkExternal = (href?: string) => !!href?.match(/^(www|http)/i)
 
-function GetMdxComponents(theme: Theme, title: string | null) {
+function GetMdxComponents(theme: Theme) {
   return {
     a: (props: LinkProps & { href: string }) => {
       if (isLinkExternal(props.href)) {
@@ -349,7 +349,7 @@ function getMdxComponent(page: MdxPage, theme: Theme | null) {
         </header>
         <Component
           /* @ts-expect-error: Does not like the link tage type definition above */
-          components={GetMdxComponents(theme, frontmatter.title)}
+          components={GetMdxComponents(theme)}
           {...rest}
         />
       </>


### PR DESCRIPTION
Adding frontmatter information (title, description) inside `<header>` as `<h1>` and  `<p>`
Issue: https://github.com/onflow/next-docs-v1/issues/330

Example Frontmatter:
<img width="1503" alt="Screen Shot 2022-06-27 at 3 41 13 PM" src="https://user-images.githubusercontent.com/18616121/176022556-2d0df8dd-96d6-4a28-a774-26575ef120d4.png">

Rendered Page:
<img width="1512" alt="Screen Shot 2022-06-27 at 3 41 19 PM" src="https://user-images.githubusercontent.com/18616121/176022583-b9ccc024-78a6-4f42-970b-088407144b27.png">

