### PR TITLE
Style markdown with the tailwind typography plugin

### DIFF
--- a/app/cms/utils/mdx.tsx
+++ b/app/cms/utils/mdx.tsx
@@ -290,12 +290,17 @@ function GetMdxComponents(theme: Theme | null) {
   return {
     a: (props: LinkProps & { href: string }) => {
       if (isLinkExternal(props.href)) {
-        // @ts-expect-error: TODO: Needs types.
-        return <Link {...props} isExternal={true} rel="noreferrer" />
+        return (
+          <Link
+            {...props}
+            isExternal={true}
+            rel="noreferrer"
+            className="not-prose"
+          />
+        )
       } else {
         return (
-          <RemixLink to={props.href}>
-            {/* @ts-expect-error: TODO: Nees types. */}
+          <RemixLink to={props.href} className="not-prose">
             <Link {...props} isExternal={false} />
           </RemixLink>
         )
@@ -303,26 +308,58 @@ function GetMdxComponents(theme: Theme | null) {
     },
     input: (props: InputProps) =>
       props.type === "checkbox" ? (
-        <StaticCheckbox {...props} asInternalChecklist={true} />
+        <StaticCheckbox
+          {...props}
+          asInternalChecklist={true}
+          className="not-prose"
+        />
       ) : (
         <input {...props} />
       ),
-    h1: (props: HeadingProps) => <Heading type="h1" {...props} />,
-    h2: (props: HeadingProps) => <Heading type="h2" {...props} />,
-    h3: (props: HeadingProps) => <Heading type="h3" {...props} />,
-    h4: (props: HeadingProps) => <Heading type="h4" {...props} />,
-    h5: (props: HeadingProps) => <Heading type="h5" {...props} />,
-    h6: (props: HeadingProps) => <Heading type="h6" {...props} />,
+    h1: (props: HeadingProps) => (
+      <Heading type="h1" {...props} className="not-prose" />
+    ),
+    h2: (props: HeadingProps) => (
+      <Heading type="h2" {...props} className="not-prose" />
+    ),
+    h3: (props: HeadingProps) => (
+      <Heading type="h3" {...props} className="not-prose" />
+    ),
+    h4: (props: HeadingProps) => (
+      <Heading type="h4" {...props} className="not-prose" />
+    ),
+    h5: (props: HeadingProps) => (
+      <Heading type="h5" {...props} className="not-prose" />
+    ),
+    h6: (props: HeadingProps) => (
+      <Heading type="h6" {...props} className="not-prose" />
+    ),
     pre: ({ children }: { className: string; children: JSX.Element }) => {
-      return <InternalCodeblock children={children} theme={theme} />
+      return (
+        <InternalCodeblock
+          children={children}
+          theme={theme}
+          className="not-prose"
+        />
+      )
     },
     Callout: (props: React.PropsWithChildren<{}>) => (
       <div>{props.children}</div>
     ),
-    Img: (props: React.PropsWithRef<{}>) => <img {...props} />,
+    Img: (props: React.PropsWithRef<{}>) => (
+      <img {...props} className="not-prose" />
+    ),
     iframe: (props: React.PropsWithRef<{ src: string; title: string }>) => {
       const { src, title, ...rest } = props
-      return <LargeVideoCard link={src} title={title} length={0} {...rest} />
+      return (
+        <LargeVideoCard
+          link={src}
+          title={title}
+          length={0}
+          {...rest}
+          className="not-prose"
+        />
+      )
     },
   }
 }

--- a/app/routes/$repo/$.tsx
+++ b/app/routes/$repo/$.tsx
@@ -55,7 +55,7 @@ export default function RepoDocument() {
   return (
     <div className="pl-[55px]">
       <div className="grid grid-cols-5">
-        <div className="col-span-4 pt-8">
+        <div className="prose col-span-4 max-w-none pt-8 dark:prose-invert">
           <MDXContent />
         </div>
         <div className="pt-[55px]">

--- a/app/ui/design-system/src/lib/Components/InternalCodeblock/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalCodeblock/index.tsx
@@ -9,12 +9,6 @@ import { ReactComponent as ScreenFullIcon } from "../../../../images/content/scr
 import { Dialog } from "../Dialog"
 import { Code } from "./Code"
 
-export type InternalCodeblockProps = {
-  tall?: boolean
-  theme: Theme | null
-  children: JSX.Element
-}
-
 function Header({
   open,
   openDialog,
@@ -56,10 +50,18 @@ function Header({
   )
 }
 
+export type InternalCodeblockProps = {
+  tall?: boolean
+  theme: Theme | null
+  children: JSX.Element
+  className?: string
+}
+
 export function InternalCodeblock({
   tall,
   theme,
   children,
+  className,
 }: InternalCodeblockProps) {
   const [open, setOpen] = useState(false)
   const openDialog = () => setOpen(true)
@@ -69,7 +71,12 @@ export function InternalCodeblock({
 
   return (
     <>
-      <div className="my-10 rounded-lg border border-primary-gray-100 text-xs dark:border-0">
+      <div
+        className={clsx(
+          className,
+          `my-10 rounded-lg border border-primary-gray-100 text-xs dark:border-0`
+        )}
+      >
         <Header
           openDialog={openDialog}
           closeDialog={closeDialog}

--- a/app/ui/design-system/src/lib/Components/Link/index.tsx
+++ b/app/ui/design-system/src/lib/Components/Link/index.tsx
@@ -14,7 +14,14 @@ export type LinkProps = React.DetailedHTMLProps<
 >
 
 //@ts-ignore: We need to figure out how to type this
-export function Link({ children, className, id, href, isExternal, ...props }) {
+export function Link({
+  children,
+  className,
+  id,
+  href,
+  isExternal,
+  ...props
+}: any) {
   const isFootnote = !!props["data-footnote-ref"]
 
   const classes = clsx(defaultClasses, {

--- a/app/ui/design-system/src/lib/Components/VideoCard/LargeVideoCard.tsx
+++ b/app/ui/design-system/src/lib/Components/VideoCard/LargeVideoCard.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx"
 import { useState } from "react"
 
 import PlayCircle from "../../../../images/action/play-circle.svg"
@@ -7,9 +8,15 @@ export interface LargeVideoCardProps {
   link: string // NOTE: link should be in the format that youtubes site uses ie: https://www.youtube.com/watch?v=...
   title: string
   length: number // seconds
+  className?: string
 }
 
-export function LargeVideoCard({ link, title, length }: LargeVideoCardProps) {
+export function LargeVideoCard({
+  link,
+  title,
+  length,
+  className,
+}: LargeVideoCardProps) {
   const [showOverlay, setShowOverlay] = useState(true)
 
   const minutes = String(Math.floor(length / 60)).padStart(2, "0")
@@ -23,7 +30,12 @@ export function LargeVideoCard({ link, title, length }: LargeVideoCardProps) {
   }
 
   return (
-    <div className="relative h-full w-full cursor-pointer rounded-lg">
+    <div
+      className={clsx(
+        className,
+        "relative h-full w-full cursor-pointer rounded-lg"
+      )}
+    >
       {showOverlay ? (
         <>
           <div


### PR DESCRIPTION
https://tailwindcss.com/docs/typography-plugin

Closes #335 

__Before and after:__

<img width="400" alt="Screen Shot 2022-06-27 at 11 40 39 AM" src="https://user-images.githubusercontent.com/921605/176013323-10593ec5-8ff0-48eb-b544-6606d3e3ffad.png"><img width="400" alt="Screen Shot 2022-06-27 at 11 40 31 AM" src="https://user-images.githubusercontent.com/921605/176013343-adf2d09e-2fd9-4183-a773-3eedc2093fb9.png">

please note that the [cadence index.mdx] document shown above uses some superfluous horizontal rows (`<hr />`) after headings