### PR TITLE
Adds "Next" and "Previous" buttons  to internal pages

### DIFF
--- a/app/ui/design-system/src/lib/Components/InternalSidebar/findSidebarSectionItem.ts
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/findSidebarSectionItem.ts
@@ -1,0 +1,26 @@
+import { InternalSidebarConfig } from "."
+
+/**
+ * Returns the `item` of the sidebar configuration item that matches the given path.
+ *
+ * @param sidebarConfig The configuration object that describes the page hierarchy.
+ * @param path The path of the item to find (relative to the repo, excluding the repo name)
+ */
+export const findSidebarSectionItem = (
+  sidebarConfig: InternalSidebarConfig | undefined,
+  path: string
+) => {
+  if (!sidebarConfig) {
+    return undefined
+  }
+
+  for (const section of sidebarConfig.sections) {
+    for (const item of section.items) {
+      if (item.href === path) {
+        return item
+      }
+    }
+  }
+
+  return undefined
+}

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/flattenSidebarSectionItems.ts
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/flattenSidebarSectionItems.ts
@@ -1,0 +1,19 @@
+import { InternalSidebarConfig } from "."
+
+/**
+ * Returns an ordered array of all `InternalSidebarSectionItem`s from
+ * all sections of the given sidebarConfig.
+ */
+export const flattenSidebarSectionItems = (
+  sidebarConfig: InternalSidebarConfig
+) => {
+  const items = []
+
+  for (const section of sidebarConfig.sections) {
+    for (const item of section.items) {
+      items.push(item)
+    }
+  }
+
+  return items
+}

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from "@remix-run/react"
 import clsx from "clsx"
 
-type InternalSidebarSectionItem = {
+export type InternalSidebarSectionItem = {
   label: string
   href: string
 }

--- a/app/ui/design-system/src/lib/Components/LowerPageNav/LowerPageNavLink.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/LowerPageNav/LowerPageNavLink.stories.tsx
@@ -39,3 +39,13 @@ longName.args = {
     name: "Quorum Certificate and Distributed Key Generation",
   },
 }
+
+export const PreviousOnly = Template.bind({})
+PreviousOnly.args = {
+  prev: Default.args.prev,
+}
+
+export const NextOnly = Template.bind({})
+NextOnly.args = {
+  next: Default.args.next,
+}

--- a/app/ui/design-system/src/lib/Components/LowerPageNav/index.tsx
+++ b/app/ui/design-system/src/lib/Components/LowerPageNav/index.tsx
@@ -6,15 +6,15 @@ export type LowerPageNavLinkType = {
 }
 
 export type LowerPageNavProps = {
-  prev: LowerPageNavLinkType
-  next: LowerPageNavLinkType
+  prev?: LowerPageNavLinkType
+  next?: LowerPageNavLinkType
 }
 
 export function LowerPageNav({ prev, next }: LowerPageNavProps) {
   return (
     <div className="flex flex-1 flex-wrap place-content-between p-6">
-      {!!prev && <LowerPageNavLink link={prev} />}
-      {!!next && <LowerPageNavLink link={next} next={true} />}
+      {prev ? <LowerPageNavLink link={prev} /> : <span />}
+      {next ? <LowerPageNavLink link={next} next={true} /> : <span />}
     </div>
   )
 }

--- a/app/ui/design-system/src/lib/Pages/InternalPage/useInternalBreadcrumbs.ts
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/useInternalBreadcrumbs.ts
@@ -1,13 +1,11 @@
 import { useMemo } from "react"
-import { InternalSidebarConfig } from "../../Components/InternalSidebar"
+import { InternalSidebarSectionItem } from "../../Components/InternalSidebar"
 
 export type UseInternalBreadcrumbsOptions = {
   /**
-   * The path of the currently active item. This should be a path
-   * relative to the repo (excluding the repo name), matching the item's href
-   * as it is defined in the sidebar configuration object.
+   * The currently active item taken from the sidebar configuration object.
    */
-  activePath: string
+  activeItem?: InternalSidebarSectionItem
 
   /**
    * THe name to display in the breadcrumbs for this content section
@@ -23,47 +21,30 @@ export type UseInternalBreadcrumbsOptions = {
    * The site's root URL.
    */
   rootUrl?: string
-
-  /**
-   * The configuration object that describes the page hierarchy.
-   */
-  sidebarConfig?: InternalSidebarConfig
-}
-
-const findItem = (sidebarConfig: InternalSidebarConfig, activePath: string) => {
-  for (const section of sidebarConfig.sections) {
-    for (const item of section.items) {
-      if (item.href === activePath) {
-        return item
-      }
-    }
-  }
 }
 
 /**
- * Returns a list of breadcrumbs based on the `activePath`
+ * Returns a list of breadcrumbs to display based on the current `activeItem`
+ * of the sidebar configuration (if any)
  */
 export const useInternalBreadcrumbs = ({
-  activePath,
+  activeItem,
   contentDisplayName,
   contentPath,
   rootUrl = "/",
-  sidebarConfig,
 }: UseInternalBreadcrumbsOptions) =>
   useMemo(() => {
-    const item = sidebarConfig && findItem(sidebarConfig, activePath)
-
     const breadcrumbs = [
       { href: rootUrl, name: "Home" },
       { name: contentDisplayName, href: `${rootUrl}${contentPath}` },
     ]
 
-    if (item) {
+    if (activeItem) {
       breadcrumbs.push({
-        name: item.label,
-        href: `${rootUrl}${contentPath}/${item.href}`,
+        name: activeItem.label,
+        href: `${rootUrl}${contentPath}/${activeItem.href}`,
       })
     }
 
     return breadcrumbs
-  }, [activePath, contentDisplayName, contentPath, rootUrl, sidebarConfig])
+  }, [activeItem, contentDisplayName, contentPath, rootUrl])


### PR DESCRIPTION
Adds the `LowerPageNav` component to internal pages.

Example (ignore the processing error):

<img width="1354" alt="Screen Shot 2022-06-27 at 3 04 17 PM" src="https://user-images.githubusercontent.com/393220/176016845-31264292-42e0-4978-82dc-6effa76cffa7.png">

Closes #332
