### PR TITLE
Internal landing header uses white text

### DIFF
--- a/app/ui/design-system/src/lib/Components/InternalLandingHeader/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalLandingHeader/index.tsx
@@ -35,7 +35,7 @@ export function InternalLandingHeader({
         <div className="flex origin-top-left scale-75 md:scale-100 md:justify-center">
           <Icon />
         </div>
-        <h1 className="text-h2 mt-2 mb-4 md:mt-10">{tool.name}</h1>
+        <h1 className="text-h2 mt-2 mb-4 text-white md:mt-10">{tool.name}</h1>
         {description}
       </div>
 


### PR DESCRIPTION
In light mode the current internal landing header uses black text:

<img width="700" alt="Screen Shot 2022-06-27 at 3 13 55 PM" src="https://user-images.githubusercontent.com/393220/176018118-f0f0be6a-a399-4775-8156-3ba8f59a59e8.png">


It should be white:

<img width="685" alt="Screen Shot 2022-06-27 at 3 13 35 PM" src="https://user-images.githubusercontent.com/393220/176018126-cb4a662c-df90-4b1b-bbbb-9708ca8f33e7.png">

