### PR TITLE
Support relative image links in markdown

### DIFF
--- a/app/cms/github.server.ts
+++ b/app/cms/github.server.ts
@@ -18,7 +18,7 @@ function debugEnv(): string {
   return JSON.stringify(process.env, null, 2)
 }
 
-const octokit = new Octokit({
+export const octokit = new Octokit({
   auth: process.env["BOT_GITHUB_TOKEN"],
   throttle: {
     onRateLimit: (retryAfter: number, options: ThrottleOptions) => {

--- a/app/routes/$repo/$.tsx
+++ b/app/routes/$repo/$.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { LoaderFunction } from "@remix-run/node"
+import { LoaderFunction, redirect } from "@remix-run/node"
 import { getMdxPage, useMdxComponent } from "~/cms/utils/mdx"
 import { json } from "@remix-run/node"
 import { Link, useCatch, useLoaderData, useLocation } from "@remix-run/react"
@@ -36,6 +36,15 @@ export const loader: LoaderFunction = async ({
 
   if (!contentSpec) {
     throw json({ status: "noRepo" }, { status: 404 })
+  }
+
+  const isDocument =
+    !path.includes(".") ||
+    path.toLowerCase().endsWith(".md") ||
+    path.toLowerCase().endsWith(".mdx")
+
+  if (!isDocument) {
+    throw redirect(`/${params.repo}/_raw/${path}`)
   }
 
   let page: MdxPage | null

--- a/app/routes/$repo/_raw/$.tsx
+++ b/app/routes/$repo/_raw/$.tsx
@@ -1,0 +1,53 @@
+import { LoaderFunction } from "@remix-run/node"
+import invariant from "tiny-invariant"
+import { octokit } from "~/cms"
+import { getContentSpec } from "~/constants/repos"
+
+const knownExtensions: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+}
+
+export const loader: LoaderFunction = async ({ params }) => {
+  const path = params["*"]
+  invariant(params.repo)
+  invariant(path)
+
+  const contentSpec = getContentSpec(params.repo)
+  if (!contentSpec) {
+    throw new Response("Not Found", {
+      status: 404,
+    })
+  }
+
+  const matchingExtension = Object.entries(knownExtensions).find(([ext]) =>
+    path.endsWith(ext)
+  )
+
+  if (!matchingExtension) {
+    throw new Response("Not Found", {
+      status: 404,
+    })
+  }
+
+  const [, contentType] = matchingExtension
+
+  const file = await octokit.repos.getContent({
+    owner: contentSpec.owner,
+    repo: contentSpec.repoName,
+    path: `${contentSpec.basePath}/${path}`,
+  })
+
+  invariant(!Array.isArray(file.data), `did not expect array`)
+  invariant("encoding" in file.data)
+  invariant(file.data.encoding === "base64", `expected base64`)
+
+  throw new Response(Buffer.from(file.data.content, file.data.encoding), {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "max-age=300",
+    },
+  })
+}


### PR DESCRIPTION
basic support for images, closes #350. only caching is done by basic http headers, and may not be that performant, but a simple solution for now.

<img width="1332" alt="Screen Shot 2022-06-28 at 5 35 24 PM" src="https://user-images.githubusercontent.com/921605/176326745-a20d75fa-c248-470a-8fb8-cb272542456c.png">
<img width="1332" alt="Screen Shot 2022-06-28 at 5 35 08 PM" src="https://user-images.githubusercontent.com/921605/176326753-a36513ca-d4a1-4c78-b1fc-40d55c2c8677.png">
<img width="1332" alt="Screen Shot 2022-06-28 at 5 34 44 PM" src="https://user-images.githubusercontent.com/921605/176326754-b70fb411-ba3c-4a64-bd46-3a875d118fca.png">
