### PR TITLE
Put repo in relative link paths

### DIFF
--- a/app/cms/compile.mdx.server.ts
+++ b/app/cms/compile.mdx.server.ts
@@ -55,30 +55,32 @@ const remarkPlugins: U.PluggableList = [
   ],
 ]
 
-const rehypePlugins: U.PluggableList = [
-  removePreContainerDivs,
-  formatLinks,
-  [
-    rehypeSanitize,
-    {
-      ...defaultSchema,
-      attributes: {
-        ...defaultSchema.attributes,
-        code: [
-          ...(defaultSchema?.attributes?.code || []),
-          [
-            "className",
-            ...HIGHLIGHT_LANGUAGES.map((name) => `language-${name}`),
+const rehypePlugins = (repoName: string): U.PluggableList => {
+  return [
+    removePreContainerDivs,
+    () => formatLinks(repoName),
+    [
+      rehypeSanitize,
+      {
+        ...defaultSchema,
+        attributes: {
+          ...defaultSchema.attributes,
+          code: [
+            ...(defaultSchema?.attributes?.code || []),
+            [
+              "className",
+              ...HIGHLIGHT_LANGUAGES.map((name) => `language-${name}`),
+            ],
           ],
-        ],
+        },
       },
-    },
-  ],
-]
-
+    ],
+  ]
+}
 async function compileMdx<FrontmatterType extends Record<string, unknown>>(
   slug: string,
-  githubFiles: Array<GitHubFile>
+  githubFiles: Array<GitHubFile>,
+  repoName: string
 ) {
   const { default: remarkSlug } = await import("remark-slug")
   const { default: gfm } = await import("remark-gfm")
@@ -112,7 +114,7 @@ async function compileMdx<FrontmatterType extends Record<string, unknown>>(
         ]
         options.rehypePlugins = [
           ...(options.rehypePlugins ?? []),
-          ...rehypePlugins,
+          ...rehypePlugins(repoName),
         ]
         return {
           ...options,

--- a/app/cms/utils/format-links.ts
+++ b/app/cms/utils/format-links.ts
@@ -16,8 +16,7 @@ function updateRelativeDepth(linkText: string, index = false) {
 
 module.exports = updateRelativeDepth
 
-// @ts-expect-error: TODO: Needs parameter types.
-const formatLinks = (...args) => {
+const formatLinks = (repoName: string) => {
   return async function rewriteRelativeLinks(tree: H.Root) {
     visit(
       tree,
@@ -36,6 +35,9 @@ const formatLinks = (...args) => {
 
           href = href.replace(/(?<=[^/])#/, "/#")
           href = href.replace(".mdx", "").replace(".md", "")
+          // remove parent or current directory paths from href, ie. remove: `../` or `./`
+          href = href.replaceAll(/(\.+\/)/g, "")
+          href = `/${repoName}/${href}`
 
           // @ts-expect-error: TODO: Needs type.
           node.properties.href = href

--- a/app/cms/utils/mdx.tsx
+++ b/app/cms/utils/mdx.tsx
@@ -257,7 +257,8 @@ async function compileMdxCached({
     getFreshValue: async () => {
       const compiledPage = await compileMdx<MdxPage["frontmatter"]>(
         fileOrDirPath,
-        files
+        files,
+        repo
       )
       if (compiledPage) {
         return {


### PR DESCRIPTION
# Description
This PR fixes the issue where the relative links are missing the root repo in their path
.../reference/api where it should be .../**fcl-js**/reference/api

closes #369 