### PR TITLE
Update internal page layout

### DIFF
--- a/app/routes/$repo/$.tsx
+++ b/app/routes/$repo/$.tsx
@@ -1,6 +1,5 @@
 import { json, LoaderFunction, redirect } from "@remix-run/node"
 import { Link, useCatch, useLoaderData, useLocation } from "@remix-run/react"
-import { useEffect, useState } from "react"
 import invariant from "tiny-invariant"
 import { getMdxPage, useMdxComponent } from "~/cms/utils/mdx"
 import {
@@ -10,7 +9,6 @@ import {
   getContentSpec,
 } from "~/constants/repos"
 import { ErrorPage } from "~/ui/design-system/src/lib/Components/ErrorPage"
-import { InternalToc } from "~/ui/design-system/src/lib/Components/InternalToc"
 import { MdxPage } from "../../cms"
 import { ToolName } from "../../ui/design-system/src/lib/Components/Internal/tools"
 import { InternalPage } from "../../ui/design-system/src/lib/Pages/InternalPage"
@@ -71,14 +69,8 @@ export const loader: LoaderFunction = async ({
 
 export default function RepoDocument() {
   const { content, path, page } = useLoaderData<LoaderData>()
-  const location = useLocation()
   const MDXContent = useMdxComponent(page)
-  const [currentHash, setHash] = useState("")
   const tool = contentTools[content.contentName]
-
-  useEffect(() => {
-    setHash(location.hash)
-  }, [location.hash])
 
   return (
     <InternalPage
@@ -94,23 +86,9 @@ export default function RepoDocument() {
         }
       }
       githubUrl={page.editLink}
+      toc={page.toc}
     >
-      <div className="pl-[55px]">
-        <div className="grid grid-cols-5">
-          <div className="mdx-content prose col-span-4 max-w-none pt-8 dark:prose-invert">
-            <MDXContent />
-          </div>
-          <div className="pt-[55px]">
-            {page.toc != null ? (
-              <InternalToc
-                headings={page.toc}
-                currentHash={currentHash}
-                updateHash={(e) => setHash("#test")}
-              />
-            ) : null}
-          </div>
-        </div>
-      </div>
+      <MDXContent />
     </InternalPage>
   )
 }

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/InternalSidebar.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/InternalSidebar.stories.tsx
@@ -4,10 +4,15 @@ import { InternalSidebar, InternalSidebarProps, TEMP_SIDEBAR_CONFIG } from "."
 export default {
   component: InternalSidebar,
   title: "Components/InternalSidebar",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<InternalSidebarProps> = (args) => (
-  <InternalSidebar {...args} />
+  <div style={{ width: "300px" }}>
+    <InternalSidebar {...args} />
+  </div>
 )
 
 export const Default = Template.bind({})

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
@@ -54,17 +54,6 @@ export const TEMP_SIDEBAR_CONFIG: InternalSidebarConfig = {
   ],
 }
 
-export function InternalSidebarContainer(props: {
-  children?: React.ReactNode
-}) {
-  return (
-    <div
-      className="mb-8 w-full min-w-min flex-1 shrink-0 bg-gray-100 bg-opacity-80 p-8 dark:bg-primary-gray-dark md:mb-0 md:w-80"
-      {...props}
-    />
-  )
-}
-
 export function InternalSidebar({ config }: InternalSidebarProps) {
   return (
     <>

--- a/app/ui/design-system/src/lib/Components/InternalToc/InternalToc.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalToc/InternalToc.stories.tsx
@@ -4,6 +4,9 @@ import { InternalToc, InternalTocProps } from "."
 export default {
   component: InternalToc,
   title: "Components/InternalToc",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<InternalTocProps> = (args) => <InternalToc {...args} />
@@ -12,13 +15,13 @@ export const Default = Template.bind({})
 
 Default.args = {
   headings: [
-    { id: "introduction", value: "Introduction" },
-    { id: "links", value: "Links" },
-    { id: "unordered-list", value: "Unordered List" },
-    { id: "ordered-list", value: "Ordered List" },
-    { id: "task-list", value: "Task List" },
-    { id: "table", value: "Table" },
-    { id: "footnote", value: "Footnote" },
+    { hash: "introduction", title: "Introduction" },
+    { hash: "links", title: "Links" },
+    { hash: "unordered-list", title: "Unordered List" },
+    { hash: "ordered-list", title: "Ordered List" },
+    { hash: "task-list", title: "Task List" },
+    { hash: "table", title: "Table" },
+    { hash: "footnote", title: "Footnote" },
   ],
   location: new URL("localhost:4400/#introduction"),
 }

--- a/app/ui/design-system/src/lib/Components/InternalToc/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalToc/index.tsx
@@ -21,13 +21,7 @@ export function InternalToc({
   }
 
   return (
-    <div
-      className="sticky top-[92px] ml-auto h-auto w-full shrink-0 flex-col self-start overflow-y-auto p-4"
-      // 96px (main nav height) + 37px (bread crumb height) + 55px (top padding) + 20px (bottom padding) = 208px
-      // if this list overflows, make it fit within the space between
-      // the breadcrumbs and bottom of the viewport
-      style={{ maxHeight: "calc(100vh - 208px)" }}
-    >
+    <div>
       <div className="mb-6 px-5 text-2xs uppercase text-gray-500">
         On this page
       </div>

--- a/app/ui/design-system/src/lib/Components/LowerPageNav/LowerPageNavLink.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/LowerPageNav/LowerPageNavLink.stories.tsx
@@ -4,6 +4,9 @@ import { LowerPageNav, LowerPageNavProps } from "."
 export default {
   component: LowerPageNav,
   title: "Components/LowerPageNav",
+  parameters: {
+    layout: "padded",
+  },
 } as Meta
 
 const Template: Story<LowerPageNavProps> = (args) => <LowerPageNav {...args} />

--- a/app/ui/design-system/src/lib/Components/LowerPageNav/index.tsx
+++ b/app/ui/design-system/src/lib/Components/LowerPageNav/index.tsx
@@ -12,7 +12,7 @@ export type LowerPageNavProps = {
 
 export function LowerPageNav({ prev, next }: LowerPageNavProps) {
   return (
-    <div className="flex flex-1 flex-wrap place-content-between p-6">
+    <div className="flex flex-1 flex-wrap place-content-between">
       {prev ? <LowerPageNavLink link={prev} /> : <span />}
       {next ? <LowerPageNavLink link={next} next={true} /> : <span />}
     </div>

--- a/app/ui/design-system/src/lib/Components/TutorialCard/PaginatedTutorialCardList.tsx
+++ b/app/ui/design-system/src/lib/Components/TutorialCard/PaginatedTutorialCardList.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import TutorialCard, { TutorialCardProps } from "."
+import { useIsomorphicLayoutEffect } from "../../utils/useIsomorphicLayoutEffect"
 import Pagination from "../Pagination"
 
 export type PaginatedTutorialCardListProps = {
@@ -42,7 +43,7 @@ export const PaginatedTutorialCardList = ({
     setPage(1)
   }, [listId])
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!scrollRef.current || resetScroll === 0 || !scrollOnPaginate) {
       return
     }

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -1,3 +1,6 @@
+import { useLocation } from "@remix-run/react"
+import clsx from "clsx"
+import { useCallback, useRef, useState } from "react"
 import {
   InternalLandingHeader,
   InternalLandingHeaderProps,
@@ -5,7 +8,6 @@ import {
 import {
   InternalSidebar,
   InternalSidebarConfig,
-  InternalSidebarContainer,
   InternalSidebarSectionItem,
 } from "../../Components/InternalSidebar"
 import { findSidebarSectionItem } from "../../Components/InternalSidebar/findSidebarSectionItem"
@@ -15,17 +17,18 @@ import {
   InternalSidebarMenuProps,
 } from "../../Components/InternalSidebarMenu"
 import { InternalSubnav } from "../../Components/InternalSubnav"
+import { InternalToc, InternalTocItem } from "../../Components/InternalToc"
 import { LowerPageNav } from "../../Components/LowerPageNav"
+import {
+  useResizeObserver,
+  UseResizeObserverCallback,
+} from "../../utils/useResizeObserver"
 import {
   useInternalBreadcrumbs,
   UseInternalBreadcrumbsOptions,
 } from "./useInternalBreadcrumbs"
 
 export type InternalPageProps = React.PropsWithChildren<{
-  githubUrl?: string
-  header?: InternalLandingHeaderProps
-  internalSidebarMenu?: InternalSidebarMenuProps
-
   /**
    * The path of the currently active item. This should be a path
    * relative to the repo (excluding the repo name), matching the item's href
@@ -33,10 +36,18 @@ export type InternalPageProps = React.PropsWithChildren<{
    */
   activePath: string
 
+  githubUrl?: string
+
+  header?: InternalLandingHeaderProps
+
+  internalSidebarMenu?: InternalSidebarMenuProps
+
   /**
    * The configuration object that describes the page hierarchy.
    */
   sidebarConfig?: InternalSidebarConfig
+
+  toc?: InternalTocItem[]
 }> &
   Omit<UseInternalBreadcrumbsOptions, "activeItem">
 
@@ -47,9 +58,10 @@ export function InternalPage({
   contentPath,
   githubUrl,
   header,
+  internalSidebarMenu,
   rootUrl = "/",
   sidebarConfig,
-  internalSidebarMenu,
+  toc,
 }: InternalPageProps) {
   const activeItem = findSidebarSectionItem(sidebarConfig, activePath)
   const breadcrumbs = useInternalBreadcrumbs({
@@ -58,7 +70,6 @@ export function InternalPage({
     contentPath,
     rootUrl,
   })
-
   let prevItem: InternalSidebarSectionItem | undefined
   let nextItem: InternalSidebarSectionItem | undefined
 
@@ -69,42 +80,85 @@ export function InternalPage({
     nextItem = activeItemIndex >= 0 ? allItems[activeItemIndex + 1] : undefined
   }
 
+  const location = useLocation()
+  const [currentHash, setHash] = useState(location.hash)
+
+  const subnavRef = useRef<HTMLDivElement>(null)
+  const [subnavRect, setSubnavRect] = useState<DOMRect>()
+  const resizeObserverCallback = useCallback<UseResizeObserverCallback>(() => {
+    setSubnavRect(subnavRef.current?.getBoundingClientRect())
+  }, [subnavRef, setSubnavRect])
+  useResizeObserver(subnavRef, resizeObserverCallback)
+
   return (
     <div className="flex flex-col">
-      <InternalSubnav
-        items={breadcrumbs}
-        className="sticky top-0 z-20"
-        githubUrl={githubUrl}
-      />
+      <div className="sticky top-0 z-20" ref={subnavRef}>
+        <InternalSubnav items={breadcrumbs} githubUrl={githubUrl} />
+      </div>
       {header && <InternalLandingHeader {...header} />}
-      <div className="flex flex-1 flex-row">
+      <div className="flex flex-1">
         {sidebarConfig && (
-          <div className="flex flex-col">
-            <InternalSidebarContainer>
+          <aside className="w-[300px] flex-none bg-gray-100 bg-opacity-80 dark:bg-primary-gray-dark">
+            <div
+              className="sticky h-full max-h-screen overflow-auto p-8"
+              style={{
+                top: subnavRect?.height ?? 0,
+                maxHeight: `calc(100vh - ${subnavRect?.bottom ?? 0}px)`,
+              }}
+            >
               {internalSidebarMenu ? (
                 <InternalSidebarMenu {...internalSidebarMenu} />
               ) : null}
               <InternalSidebar config={sidebarConfig} />
-            </InternalSidebarContainer>
-          </div>
+            </div>
+          </aside>
         )}
-        <div className="flex flex-1 flex-col">
-          <div className="pb-6">{children}</div>
-          <LowerPageNav
-            prev={
-              prevItem && {
-                href: `${rootUrl}${contentPath}/${prevItem.href}`,
-                name: prevItem.label,
+        <main
+          className={clsx("flex shrink grow-0 flex-row-reverse	", {
+            "max-w-[calc(100%_-_300px)]": sidebarConfig,
+            "max-w-full": !sidebarConfig,
+          })}
+        >
+          {toc && (
+            <div className="w-1/4 flex-none">
+              <div
+                className="sticky h-full max-h-screen overflow-auto p-8"
+                style={{
+                  top: subnavRect?.height ?? 0,
+                  maxHeight: `calc(100vh - ${subnavRect?.bottom ?? 0}px)`,
+                }}
+              >
+                <InternalToc
+                  headings={toc}
+                  currentHash={currentHash}
+                  updateHash={(e) => setHash("#test")}
+                />
+              </div>
+            </div>
+          )}
+          <div
+            className={clsx("flex-none p-8 pl-16", {
+              "w-3/4": !!toc,
+              "w-full": !toc,
+            })}
+          >
+            <div className="">{children}</div>
+            <LowerPageNav
+              prev={
+                prevItem && {
+                  href: `${rootUrl}${contentPath}/${prevItem.href}`,
+                  name: prevItem.label,
+                }
               }
-            }
-            next={
-              nextItem && {
-                href: `${rootUrl}${contentPath}/${nextItem.href}`,
-                name: nextItem.label,
+              next={
+                nextItem && {
+                  href: `${rootUrl}${contentPath}/${nextItem.href}`,
+                  name: nextItem.label,
+                }
               }
-            }
-          />
-        </div>
+            />
+          </div>
+        </main>
       </div>
     </div>
   )

--- a/app/ui/design-system/src/lib/utils/canUseDOM.ts
+++ b/app/ui/design-system/src/lib/utils/canUseDOM.ts
@@ -1,0 +1,6 @@
+// Taken from: https://remix.run/docs/en/v1/guides/constraints#uselayouteffect
+export const canUseDOM = !!(
+  typeof window !== "undefined" &&
+  window.document &&
+  window.document.createElement
+)

--- a/app/ui/design-system/src/lib/utils/useIsomorphicLayoutEffect.ts
+++ b/app/ui/design-system/src/lib/utils/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,4 @@
+import { useLayoutEffect, useEffect } from "react"
+import { canUseDOM } from "./canUseDOM"
+
+export const useIsomorphicLayoutEffect = canUseDOM ? useLayoutEffect : useEffect

--- a/app/ui/design-system/src/lib/utils/useResizeObserver.ts
+++ b/app/ui/design-system/src/lib/utils/useResizeObserver.ts
@@ -1,0 +1,68 @@
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect"
+
+export type UseResizeObserverCallback = (target?: ResizeObserverEntry) => void
+
+class SharedResizeObserver {
+  callbacks = new WeakMap<Element, UseResizeObserverCallback>()
+  sharedResizeObserver?: ResizeObserver
+
+  constructor() {
+    if (typeof window !== "undefined" && window.ResizeObserver) {
+      this.sharedResizeObserver = new ResizeObserver(
+        this.updateResizedElements.bind(this)
+      )
+    }
+  }
+
+  updateResizedElements(entries: ResizeObserverEntry[]) {
+    for (const entry of entries) {
+      const callbackForElement = this.callbacks.get(entry.target)
+      if (callbackForElement) callbackForElement(entry)
+    }
+  }
+
+  observe(element: Element, callback: UseResizeObserverCallback) {
+    if (!this.sharedResizeObserver) return
+    this.sharedResizeObserver.observe(element)
+    this.callbacks.set(element, callback)
+  }
+
+  unobserve(element: Element) {
+    if (!this.sharedResizeObserver) return
+    this.sharedResizeObserver.unobserve(element)
+    this.callbacks.delete(element)
+  }
+}
+
+/**
+ * It is recommended to only have a single ResizeObserver for performance
+ * reasons.
+ * @see {@link https://github.com/WICG/resize-observer/issues/59#issuecomment-408098151}
+ */
+const sharedResizeObserver = new SharedResizeObserver()
+
+/**
+ * A hook that observers an element and calls a function when it is resized.
+ *
+ * @param ref A ref to the element to be observerd
+ * @param callback A callback that will be called when the element is resized.
+ *   This should be memoized!
+ */
+export const useResizeObserver = <T extends HTMLElement>(
+  ref: React.RefObject<T>,
+  callback: UseResizeObserverCallback
+) => {
+  useIsomorphicLayoutEffect(() => {
+    const { current } = ref
+
+    if (!current) {
+      return
+    }
+
+    sharedResizeObserver.observe(current, callback)
+
+    return () => {
+      sharedResizeObserver.unobserve(current)
+    }
+  }, [ref, callback])
+}

--- a/app/ui/design-system/src/lib/utils/useResizeObserver.ts
+++ b/app/ui/design-system/src/lib/utils/useResizeObserver.ts
@@ -39,7 +39,7 @@ class SharedResizeObserver {
  * reasons.
  * @see {@link https://github.com/WICG/resize-observer/issues/59#issuecomment-408098151}
  */
-const sharedResizeObserver = new SharedResizeObserver()
+const resizeObserverSingleton = new SharedResizeObserver()
 
 /**
  * A hook that observers an element and calls a function when it is resized.
@@ -59,10 +59,10 @@ export const useResizeObserver = <T extends HTMLElement>(
       return
     }
 
-    sharedResizeObserver.observe(current, callback)
+    resizeObserverSingleton.observe(current, callback)
 
     return () => {
-      sharedResizeObserver.unobserve(current)
+      resizeObserverSingleton.unobserve(current)
     }
   }, [ref, callback])
 }


### PR DESCRIPTION
This updates and simplifies the `InternalPage` layout to the desired design for desktop. The heights of the sidebars are now calculated based on the actual height/position of the navbar as opposed to hard-coding expected heights. 

Also adds a few utilities:

- `canUseDOM` can be used to determine if the DOM is available (i.e. are we server-side rendering?)
- `useIsomorphicLayoutEffect` a `useLayoutEffect` replacement that can be safely used when server-side rendering.
- `useResizeObserver` provides the ability to watch an element for resize events in a performant way.

Will follow this up with mobile features as described in #368