### PR TITLE
Mobile internal page navigation

### DIFF
--- a/app/ui/design-system/images/action/menu.svg
+++ b/app/ui/design-system/images/action/menu.svg
@@ -1,4 +1,4 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M3 12H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M3 6H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M3 18H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
@@ -21,7 +21,7 @@ export type InternalSidebarConfig = {
 
 export type InternalSidebarProps = {
   config: InternalSidebarConfig
-  menu: InternalSidebarMenuProps
+  menu?: InternalSidebarMenuProps
 }
 
 export const TEMP_SIDEBAR_CONFIG: InternalSidebarConfig = {

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
@@ -1,5 +1,9 @@
 import { NavLink } from "@remix-run/react"
 import clsx from "clsx"
+import {
+  InternalSidebarMenu,
+  InternalSidebarMenuProps,
+} from "../InternalSidebarMenu"
 
 export type InternalSidebarSectionItem = {
   label: string
@@ -17,6 +21,7 @@ export type InternalSidebarConfig = {
 
 export type InternalSidebarProps = {
   config: InternalSidebarConfig
+  menu: InternalSidebarMenuProps
 }
 
 export const TEMP_SIDEBAR_CONFIG: InternalSidebarConfig = {
@@ -54,9 +59,10 @@ export const TEMP_SIDEBAR_CONFIG: InternalSidebarConfig = {
   ],
 }
 
-export function InternalSidebar({ config }: InternalSidebarProps) {
+export function InternalSidebar({ config, menu }: InternalSidebarProps) {
   return (
     <>
+      {menu && <InternalSidebarMenu {...menu} />}
       {config.sections.map((section) => (
         <div
           className="border-b-1 mb-2 border-b border-b-gray-300 py-4 last:border-b-0 dark:border-b-gray-700"

--- a/app/ui/design-system/src/lib/Components/InternalSubnav/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSubnav/index.tsx
@@ -2,10 +2,13 @@ import clsx from "clsx"
 import { ReactComponent as GithubLogo } from "../../../../images/social/github"
 import { Breadcrumbs, BreadcrumbsProps } from "../Breadcrumbs"
 import { InternalVersionSelect, Version } from "../InternalVersionSelect"
+import { MobileMenuToggleButton } from "../NavigationBar/MobileMenuToggleButton"
 
 export type InternalSubnavProps = BreadcrumbsProps & {
   className?: string
   githubUrl?: string
+  isSidebarOpen?: boolean
+  onSidebarToggle?: () => void
   selectedVersionName?: string
   versions?: Version[]
 }
@@ -14,20 +17,31 @@ export function InternalSubnav({
   className,
   githubUrl,
   items,
+  isSidebarOpen,
+  onSidebarToggle,
   selectedVersionName,
   versions,
 }: InternalSubnavProps) {
   return (
     <div
       className={clsx(
-        "flex flex-wrap items-center justify-between border-b border-b-primary-gray-100 bg-white py-2 px-6 dark:border-b-primary-gray-300 dark:bg-black",
+        "flex flex-wrap items-center justify-between border-b border-b-primary-gray-100 bg-white px-6 dark:border-b-primary-gray-300 dark:bg-black",
         className
       )}
     >
-      <div className="pr-2">
+      <div className="flex items-start py-2 pr-2 ">
+        {isSidebarOpen !== undefined && onSidebarToggle !== undefined && (
+          <MobileMenuToggleButton
+            className="mr-3 md:hidden"
+            height="20px"
+            isOpen={isSidebarOpen}
+            onOpenChanged={() => onSidebarToggle()}
+          />
+        )}
+
         <Breadcrumbs items={items} />
       </div>
-      <div className="flex items-center">
+      <div className="flex items-center py-2 ">
         {!!selectedVersionName && !!versions && (
           <InternalVersionSelect
             versions={versions}
@@ -35,8 +49,8 @@ export function InternalSubnav({
           />
         )}
         {githubUrl && (
-          <a href={githubUrl} className="whitespace-nowrap">
-            <GithubLogo className="inline" /> Edit on Github
+          <a href={githubUrl} className="whitespace-nowrap text-sm">
+            <GithubLogo className="inline scale-90" /> Edit on Github
           </a>
         )}
       </div>

--- a/app/ui/design-system/src/lib/Components/InternalToc/InternalToc.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalToc/InternalToc.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, Story } from "@storybook/react"
-import { InternalToc, InternalTocProps } from "."
+import { InternalToc, InternalTocDisclosure, InternalTocProps } from "."
 
 export default {
   component: InternalToc,
@@ -14,6 +14,25 @@ const Template: Story<InternalTocProps> = (args) => <InternalToc {...args} />
 export const Default = Template.bind({})
 
 Default.args = {
+  headings: [
+    { hash: "introduction", title: "Introduction" },
+    { hash: "links", title: "Links" },
+    { hash: "unordered-list", title: "Unordered List" },
+    { hash: "ordered-list", title: "Ordered List" },
+    { hash: "task-list", title: "Task List" },
+    { hash: "table", title: "Table" },
+    { hash: "footnote", title: "Footnote" },
+  ],
+  location: new URL("localhost:4400/#introduction"),
+}
+
+const DisclosureTemplate: Story<InternalTocProps> = (args) => (
+  <InternalTocDisclosure {...args} />
+)
+
+export const Disclosure = DisclosureTemplate.bind({})
+
+Disclosure.args = {
   headings: [
     { hash: "introduction", title: "Introduction" },
     { hash: "links", title: "Links" },

--- a/app/ui/design-system/src/lib/Components/InternalToc/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalToc/index.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from "react"
 import clsx from "clsx"
 import { useLocation } from "@remix-run/react"
+import { Disclosure } from "@headlessui/react"
+import { ReactComponent as ChevronDownIcon } from "../../../../images/arrows/chevron-down"
+import { ReactComponent as ChevronUpIcon } from "../../../../images/arrows/chevron-up"
 
 export type InternalTocItem = {
   title: string
@@ -88,6 +91,36 @@ export function InternalToc({ headings }: InternalTocProps) {
           </div>
         ))}
       </div>
+    </div>
+  )
+}
+
+export function InternalTocDisclosure({
+  headings,
+}: Omit<InternalTocProps, "currentHash" | "updateHash">) {
+  return (
+    <div className="rounded-md bg-primary-gray-50 p-2 dark:bg-primary-gray-400">
+      <Disclosure>
+        {({ open }) => (
+          <>
+            <Disclosure.Button className="flex w-full justify-between">
+              On this page
+              <span>{open ? <ChevronUpIcon /> : <ChevronDownIcon />}</span>
+            </Disclosure.Button>
+            <Disclosure.Panel className="mt-2 flex flex-col border-t border-t-gray-400 pt-1">
+              {headings.map(({ title, hash }, index) => (
+                <a
+                  key={index}
+                  href={hash}
+                  className="my-1 text-primary-gray-400 hover:opacity-75 dark:text-gray-200"
+                >
+                  {title}
+                </a>
+              ))}
+            </Disclosure.Panel>
+          </>
+        )}
+      </Disclosure>
     </div>
   )
 }

--- a/app/ui/design-system/src/lib/Components/NavigationBar/MobileMenuToggleButton.tsx
+++ b/app/ui/design-system/src/lib/Components/NavigationBar/MobileMenuToggleButton.tsx
@@ -1,4 +1,5 @@
 import { Transition } from "@headlessui/react"
+import clsx from "clsx"
 import { Fragment } from "react"
 import { ReactComponent as CloseIcon } from "../../../../images/action/close"
 import { ReactComponent as MenuIcon } from "../../../../images/action/menu"
@@ -6,17 +7,24 @@ import { ReactComponent as MenuIcon } from "../../../../images/action/menu"
 export type MobileMenuToggleButtonProps = {
   isOpen: boolean
   onOpenChanged: (open: boolean) => void
+  height?: string
+  width?: string
+  className?: string
 }
 
 export function MobileMenuToggleButton({
+  className,
+  height = "26px",
+  width = height,
   isOpen,
   onOpenChanged,
 }: MobileMenuToggleButtonProps) {
   return (
     <button
-      className="relative h-[26px] w-[26px]"
+      className={clsx("relative", className)}
       onClick={() => onOpenChanged(!isOpen)}
       type="button"
+      style={{ height, width }}
     >
       <Transition
         as={Fragment}
@@ -29,7 +37,7 @@ export function MobileMenuToggleButton({
         leaveTo="opacity-0 scale-95 "
       >
         <div className="absolute top-0 left-0 bottom-0 right-0">
-          <CloseIcon height="26px" width="26px" />
+          <CloseIcon height={height} width={width} />
         </div>
       </Transition>
       <Transition
@@ -43,7 +51,7 @@ export function MobileMenuToggleButton({
         leaveTo="opacity-0 scale-95 "
       >
         <div className="absolute top-0 left-0 bottom-0 right-0">
-          <MenuIcon height="26px" width="26px" />
+          <MenuIcon height={height} width={width} />
         </div>
       </Transition>
     </button>

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -1,3 +1,4 @@
+import { Transition } from "@headlessui/react"
 import clsx from "clsx"
 import { useCallback, useRef, useState } from "react"
 import {
@@ -11,13 +12,15 @@ import {
 } from "../../Components/InternalSidebar"
 import { findSidebarSectionItem } from "../../Components/InternalSidebar/findSidebarSectionItem"
 import { flattenSidebarSectionItems } from "../../Components/InternalSidebar/flattenSidebarSectionItems"
-import {
-  InternalSidebarMenu,
-  InternalSidebarMenuProps,
-} from "../../Components/InternalSidebarMenu"
+import { InternalSidebarMenuProps } from "../../Components/InternalSidebarMenu"
 import { InternalSubnav } from "../../Components/InternalSubnav"
-import { InternalToc, InternalTocItem } from "../../Components/InternalToc"
+import {
+  InternalToc,
+  InternalTocDisclosure,
+  InternalTocItem,
+} from "../../Components/InternalToc"
 import { LowerPageNav } from "../../Components/LowerPageNav"
+import { MobileMenuToggleButton } from "../../Components/NavigationBar/MobileMenuToggleButton"
 import {
   useResizeObserver,
   UseResizeObserverCallback,
@@ -62,6 +65,8 @@ export function InternalPage({
   sidebarConfig,
   toc,
 }: InternalPageProps) {
+  const [isMobileSidebarOpen, setMobileSidebarOpen] = useState(false)
+
   const activeItem = findSidebarSectionItem(sidebarConfig, activePath)
   const breadcrumbs = useInternalBreadcrumbs({
     activeItem,
@@ -89,34 +94,74 @@ export function InternalPage({
   return (
     <div className="flex flex-col">
       <div className="sticky top-0 z-20" ref={subnavRef}>
-        <InternalSubnav items={breadcrumbs} githubUrl={githubUrl} />
+        <InternalSubnav
+          isSidebarOpen={isMobileSidebarOpen}
+          onSidebarToggle={() => setMobileSidebarOpen(!isMobileSidebarOpen)}
+          items={breadcrumbs}
+          githubUrl={githubUrl}
+        />
       </div>
       {header && <InternalLandingHeader {...header} />}
-      <div className="flex flex-1">
+      {sidebarConfig && (
+        <Transition
+          unmount={false}
+          as="div"
+          className="fixed left-0 right-0 bottom-0 z-40 bg-white dark:bg-black md:hidden"
+          style={{
+            top: subnavRect ? subnavRect.top : 0,
+          }}
+          show={isMobileSidebarOpen}
+          enter="transform transition duration-300 ease-in-out"
+          enterFrom="-translate-x-full"
+          enterTo="translate-x-0"
+          leave="transform duration-300 transition ease-in-out"
+          leaveFrom="translate-x-0"
+          leaveTo="-translate-x-full"
+        >
+          <div className="mb-2 border-b border-b-primary-gray-100 px-6 pt-1 pb-2 dark:border-b-primary-gray-300">
+            <MobileMenuToggleButton
+              className="mr-4 md:hidden"
+              height="20px"
+              isOpen
+              onOpenChanged={() => setMobileSidebarOpen(false)}
+            />
+          </div>
+          <div className="p-6">
+            <InternalSidebar
+              config={sidebarConfig}
+              menu={internalSidebarMenu}
+            />
+          </div>
+        </Transition>
+      )}
+
+      <div className="relative flex flex-1">
         {sidebarConfig && (
-          <aside className="w-[300px] flex-none bg-gray-100 bg-opacity-80 dark:bg-primary-gray-dark">
-            <div
-              className="sticky h-full max-h-screen overflow-auto p-8"
-              style={{
-                top: subnavRect?.height ?? 0,
-                maxHeight: `calc(100vh - ${subnavRect?.bottom ?? 0}px)`,
-              }}
-            >
-              {internalSidebarMenu ? (
-                <InternalSidebarMenu {...internalSidebarMenu} />
-              ) : null}
-              <InternalSidebar config={sidebarConfig} />
-            </div>
-          </aside>
+          <>
+            <aside className="hidden w-[300px] flex-none md:block">
+              <div
+                className="sticky h-full max-h-screen overflow-auto p-8"
+                // className="fixed top-0 bottom-0 left-0 right-0 h-full overflow-auto bg-gray-100 bg-opacity-80 p-8 dark:bg-primary-gray-dark md:sticky"
+                style={{
+                  top: subnavRect?.height ?? 0,
+                  maxHeight: `calc(100vh - ${subnavRect?.bottom ?? 0}px)`,
+                }}
+              >
+                <InternalSidebar
+                  config={sidebarConfig}
+                  menu={internalSidebarMenu}
+                />
+              </div>
+            </aside>
+          </>
         )}
         <main
-          className={clsx("flex shrink grow-0 flex-row-reverse	", {
-            "max-w-[calc(100%_-_300px)]": sidebarConfig,
-            "max-w-full": !sidebarConfig,
+          className={clsx("flex max-w-full shrink grow-0 flex-row-reverse", {
+            "md:max-w-[calc(100%_-_300px)]": sidebarConfig,
           })}
         >
           {toc && (
-            <div className="w-1/4 flex-none">
+            <div className="hidden flex-none md:flex md:w-1/4">
               <div
                 className="sticky h-full max-h-screen overflow-auto p-8"
                 style={{
@@ -129,12 +174,16 @@ export function InternalPage({
             </div>
           )}
           <div
-            className={clsx("flex-none p-8 pl-16", {
-              "w-3/4": !!toc,
-              "w-full": !toc,
+            className={clsx("w-full flex-none p-8 pl-16", {
+              "md:w-3/4": !!toc,
             })}
           >
-            <div className="">{children}</div>
+            {toc && (
+              <div className="md:hidden">
+                <InternalTocDisclosure headings={toc} />
+              </div>
+            )}
+            <div>{children}</div>
             <LowerPageNav
               prev={
                 prevItem && {

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -141,7 +141,6 @@ export function InternalPage({
             <aside className="hidden w-[300px] flex-none md:block">
               <div
                 className="sticky h-full max-h-screen overflow-auto p-8"
-                // className="fixed top-0 bottom-0 left-0 right-0 h-full overflow-auto bg-gray-100 bg-opacity-80 p-8 dark:bg-primary-gray-dark md:sticky"
                 style={{
                   top: subnavRect?.height ?? 0,
                   maxHeight: `calc(100vh - ${subnavRect?.bottom ?? 0}px)`,


### PR DESCRIPTION
Builds on #371 to add the mobile implementation. Both sidebars collapse, with the right sidebar being put into a collapsible "accordion" at the top of the page:


![Kapture 2022-07-05 at 11 43 04](https://user-images.githubusercontent.com/393220/177366408-91bd1e0f-1c3d-42d5-a5d7-034bddffd582.gif)

and the left sidebar being toggle-able by a button in the internal navigation header:


![Kapture 2022-07-05 at 11 44 25](https://user-images.githubusercontent.com/393220/177366674-4c78042f-beb6-442c-968b-16ced1822965.gif)


Fixed #368