### PR TITLE
Fix heading and link style issues on internal pages

### DIFF
--- a/app/cms/utils/mdx.tsx
+++ b/app/cms/utils/mdx.tsx
@@ -372,24 +372,12 @@ function GetMdxComponents(theme: Theme) {
       ) : (
         <input {...props} />
       ),
-    h1: (props: HeadingProps) => (
-      <Heading type="h1" {...props} className="not-prose" />
-    ),
-    h2: (props: HeadingProps) => (
-      <Heading type="h2" {...props} className="not-prose" />
-    ),
-    h3: (props: HeadingProps) => (
-      <Heading type="h3" {...props} className="not-prose" />
-    ),
-    h4: (props: HeadingProps) => (
-      <Heading type="h4" {...props} className="not-prose" />
-    ),
-    h5: (props: HeadingProps) => (
-      <Heading type="h5" {...props} className="not-prose" />
-    ),
-    h6: (props: HeadingProps) => (
-      <Heading type="h6" {...props} className="not-prose" />
-    ),
+    h1: (props: HeadingProps) => <Heading type="h1" {...props} />,
+    h2: (props: HeadingProps) => <Heading type="h2" {...props} />,
+    h3: (props: HeadingProps) => <Heading type="h3" {...props} />,
+    h4: (props: HeadingProps) => <Heading type="h4" {...props} />,
+    h5: (props: HeadingProps) => <Heading type="h5" {...props} />,
+    h6: (props: HeadingProps) => <Heading type="h6" {...props} />,
     pre: ({ children }: { className: string; children: JSX.Element }) => {
       return (
         <InternalCodeblock
@@ -436,7 +424,7 @@ function getMdxComponent(page: MdxPage, theme: Theme | null) {
     ...rest
   }: Parameters<typeof Component>["0"]) {
     return (
-      <>
+      <div className="prose dark:prose-invert">
         <header>
           <Heading type="h1" children={frontmatter.title} />
           <p>{frontmatter.description}</p>
@@ -446,7 +434,7 @@ function getMdxComponent(page: MdxPage, theme: Theme | null) {
           components={GetMdxComponents(theme)}
           {...rest}
         />
-      </>
+      </div>
     )
   }
   return MdxComponent

--- a/app/ui/design-system/src/lib/Components/Heading/index.tsx
+++ b/app/ui/design-system/src/lib/Components/Heading/index.tsx
@@ -28,7 +28,7 @@ function parameterize(string: string) {
 export function Heading({
   type = "h1",
   children,
-  className = "",
+  className,
   ...props
 }: HeadingProps) {
   const text = typeof children === "string" ? children : ""
@@ -44,11 +44,11 @@ export function Heading({
       <a
         href={`#${anchor}`}
         title={text}
-        className="mr-3 -mt-1 flex h-8 w-8 scale-75 items-center justify-center rounded-md bg-gray-100 hover:bg-gray-200 group-hover:visible dark:bg-primary-gray-dark dark:hover:bg-gray-700 md:invisible md:scale-100"
+        className="mr-2 -mt-1 flex h-8 w-8 flex-none items-center justify-center rounded-md bg-gray-100 hover:bg-gray-200 group-hover:visible dark:bg-primary-gray-dark dark:hover:bg-gray-700 md:invisible md:scale-100"
       >
         <LinkIcon />
       </a>
-      {children}
+      <span className="ml-1 flex-1">{children}</span>
     </div>
   )
 }

--- a/app/ui/design-system/src/lib/Components/Link/ExternalLinkIcon.tsx
+++ b/app/ui/design-system/src/lib/Components/Link/ExternalLinkIcon.tsx
@@ -1,4 +1,6 @@
-function ExternalLinkIcon() {
+export type ExternalLinkIconProps = React.ComponentPropsWithoutRef<"svg">
+
+function ExternalLinkIcon(props: ExternalLinkIconProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -6,6 +8,7 @@ function ExternalLinkIcon() {
       height="1em"
       fill="none"
       viewBox="0 0 19 18"
+      {...props}
     >
       <path
         strokeLinecap="round"

--- a/app/ui/design-system/src/lib/Components/Link/index.tsx
+++ b/app/ui/design-system/src/lib/Components/Link/index.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx"
 import ExternalLinkIcon from "./ExternalLinkIcon"
 
 const defaultClasses =
-  "leading-[1.1] relative text-primary-blue inline-flex items-center dark:text-blue-dark hover:opacity-75 dark:border-blue-dark dark:stroke-blue-dark"
+  "leading-[1.1] relative text-primary-blue dark:text-blue-dark hover:opacity-75 dark:border-blue-dark dark:stroke-blue-dark"
 
 export type LinkProps = React.DetailedHTMLProps<
   React.HTMLAttributes<HTMLAnchorElement> & {
@@ -25,7 +25,7 @@ export function Link({
   const isFootnote = !!props["data-footnote-ref"]
 
   const classes = clsx(defaultClasses, {
-    "stroke-primary-blue inline-flex": !isFootnote,
+    "stroke-primary-blue inline": !isFootnote,
     "ml-0.5": isFootnote,
   })
 
@@ -39,7 +39,7 @@ export function Link({
         >
           {children}
         </span>
-        {isExternal && <ExternalLinkIcon />}
+        {isExternal && <ExternalLinkIcon className="inline" />}
       </a>
     )
   }


### PR DESCRIPTION
Headings were being excluded from being treated as "prose", even though they may contain elements that need to be styled that way. 

Before:

<img width="437" alt="Screen Shot 2022-07-05 at 2 41 04 PM" src="https://user-images.githubusercontent.com/393220/177394125-11389f3a-8770-4317-b2b9-84485f099b6f.png">

After:

<img width="435" alt="Screen Shot 2022-07-05 at 2 40 40 PM" src="https://user-images.githubusercontent.com/393220/177394063-4de90dd4-878a-4786-889f-cf9c96b00a04.png">

---

Additionally, internal page links were being rendered as block level elements causing some weird visual problems. 

Before:
<img width="404" alt="Screen Shot 2022-07-05 at 2 26 03 PM" src="https://user-images.githubusercontent.com/393220/177393914-818c277a-c5bf-408b-8d0e-d9b0230b9ddb.png">

After:

<img width="378" alt="Screen Shot 2022-07-05 at 2 35 21 PM" src="https://user-images.githubusercontent.com/393220/177393919-cea71743-2c08-4b72-8e2a-3f4e52bba3e9.png">

Closes #354 