### PR TITLE
Allow trusted repos that skip rehypeSanitize

### DIFF
--- a/app/cms/compile.mdx.server.ts
+++ b/app/cms/compile.mdx.server.ts
@@ -55,11 +55,17 @@ const remarkPlugins: U.PluggableList = [
   ],
 ]
 
-const rehypePlugins = (repoName: string): U.PluggableList => {
-  return [
+const rehypePlugins = (
+  repoName: string,
+  isTrusted: boolean = false
+): U.PluggableList => {
+  const plugins: U.PluggableList = [
     removePreContainerDivs,
     () => formatLinks(repoName),
-    [
+  ]
+
+  if (!isTrusted) {
+    plugins.push([
       rehypeSanitize,
       {
         ...defaultSchema,
@@ -74,13 +80,17 @@ const rehypePlugins = (repoName: string): U.PluggableList => {
           ],
         },
       },
-    ],
-  ]
+    ])
+  }
+
+  return plugins
 }
+
 async function compileMdx<FrontmatterType extends Record<string, unknown>>(
   slug: string,
   githubFiles: Array<GitHubFile>,
-  repoName: string
+  repoName: string,
+  isTrusted: boolean = false
 ) {
   const { default: remarkSlug } = await import("remark-slug")
   const { default: gfm } = await import("remark-gfm")
@@ -114,7 +124,7 @@ async function compileMdx<FrontmatterType extends Record<string, unknown>>(
         ]
         options.rehypePlugins = [
           ...(options.rehypePlugins ?? []),
-          ...rehypePlugins(repoName),
+          ...rehypePlugins(repoName, isTrusted),
         ]
 
         return options

--- a/app/cms/utils/mdx.tsx
+++ b/app/cms/utils/mdx.tsx
@@ -56,11 +56,13 @@ async function getMdxPage(
     repo,
     branch,
     fileOrDirPath,
+    isTrusted,
   }: {
     owner: string
     repo: string
     branch: string
     fileOrDirPath: string
+    isTrusted: boolean
   },
   options: CachifiedOptions
 ): Promise<MdxPage | null> {
@@ -88,6 +90,7 @@ async function getMdxPage(
         branch,
         fileOrDirPath,
         ...pageFiles,
+        isTrusted,
         options,
       }).catch((err) => {
         console.error(`Failed to get a fresh value for mdx:`, {
@@ -112,6 +115,7 @@ async function getMdxPagesInDirectory(
   repo: string,
   branch: string,
   fileOrDirPath: string,
+  isTrusted: boolean,
   options: CachifiedOptions
 ) {
   const dirList = await getMdxDirList(
@@ -146,6 +150,7 @@ async function getMdxPagesInDirectory(
         branch,
         fileOrDirPath,
         ...pageData,
+        isTrusted,
         options,
       })
     )
@@ -237,6 +242,7 @@ async function compileMdxCached({
   fileOrDirPath,
   entry,
   files,
+  isTrusted,
   options,
 }: {
   owner: string
@@ -245,6 +251,7 @@ async function compileMdxCached({
   fileOrDirPath: string
   entry: string
   files: Array<GitHubFile>
+  isTrusted: boolean
   options: CachifiedOptions
 }) {
   const key = getCompiledKey(owner, repo, branch, fileOrDirPath)
@@ -258,7 +265,8 @@ async function compileMdxCached({
       const compiledPage = await compileMdx<MdxPage["frontmatter"]>(
         fileOrDirPath,
         files,
-        repo
+        repo,
+        isTrusted
       )
       if (compiledPage) {
         return {

--- a/app/constants/repos/index.ts
+++ b/app/constants/repos/index.ts
@@ -49,6 +49,8 @@ import { landingHeaders } from "./custom-headers"
 export const DEFAULT_REPO_OWNER = "onflow"
 export const DEFAULT_CONTENT_PATH = "docs"
 
+const trustedRepositories = [...repositoryNames]
+
 /* Sidebar presets for all repositories and content names */
 export const schemas: Partial<Record<ContentName, RepoSchema>> = {
   // Individual repository
@@ -134,6 +136,8 @@ export type ContentSpec = {
   displayName: string
   schema?: RepoSchema
   landingHeader?: InternalLandingHeaderProps
+
+  isTrusted: boolean
 }
 
 function getBasePath(name: string) {
@@ -146,24 +150,24 @@ function getBasePath(name: string) {
   return DEFAULT_CONTENT_PATH
 }
 
-export const contentSpecMap = [
-  ...repositoryNames,
-  ...flowSectionNames,
-  ...flowContentNames,
-].reduce(
-  (accum, name) => ({
-    ...accum,
-    [name]: {
-      owner: DEFAULT_REPO_OWNER,
-      repoName: isFlowContent(name) || isFlowSection(name) ? "flow" : name,
-      branch: "master",
-      basePath: getBasePath(name),
-      contentName: name,
-      displayName: displayNames[name] || capitalCase(name),
-      schema: schemas[name],
-      landingHeader: landingHeaders[name],
-    },
-  }),
+export const contentSpecMap = [...repositoryNames, ...flowContentNames].reduce(
+  (accum, name) => {
+    const repoName = isFlowContent(name) ? "flow" : name
+    return {
+      ...accum,
+      [name]: {
+        owner: DEFAULT_REPO_OWNER,
+        repoName,
+        branch: "master",
+        basePath: getBasePath(name),
+        contentName: name,
+        displayName: displayNames[name] || capitalCase(name),
+        schema: schemas[name],
+        landingHeader: landingHeaders[name],
+        isTrusted: trustedRepositories.includes(name),
+      },
+    }
+  },
   {} as Record<ContentName, ContentSpec>
 )
 

--- a/app/routes/$repo/$.tsx
+++ b/app/routes/$repo/$.tsx
@@ -95,6 +95,7 @@ export const loader: LoaderFunction = async ({
         repo: contentSpec.repoName,
         branch: contentSpec.branch,
         fileOrDirPath: [contentSpec.basePath, path].join("/"),
+        isTrusted: contentSpec.isTrusted,
       },
       { request, forceFresh: process.env.FORCE_REFRESH === "true" }
     )

--- a/app/routes/action/refresh.tsx
+++ b/app/routes/action/refresh.tsx
@@ -88,6 +88,7 @@ export const action: ActionFunction = async ({ request }) => {
           owner: contentSpec.owner,
           repo: contentSpec.repoName,
           fileOrDirPath: contentPath,
+          isTrusted: contentSpec.isTrusted,
         },
         { forceFresh: true }
       )


### PR DESCRIPTION
The `rehypeSanitize` plugin strips anything that it doesn't recognize, which includes any JSX components. These applies to any iframe videos and is causing the video not to show up for the `fcl-js/tutorials/flow-app-quickstart` page. The only way I've been able to get around this is to disable the `rehypeSanitize` plugin all-together. We obviously only want to do that for trusted sources so this allows setting an `isTrusted` property on on the `ContentSpec` which ultimately disables the sanitization. Right now this is set to trust all current repos, but should be adjusted as needed:

```
// app/constants/repos/index.ts
const trustedRepositories = [...repositoryNames];
```
