### PR TITLE
Update landing path for flow/faq page

### DIFF
--- a/app/routes/$repo/$.tsx
+++ b/app/routes/$repo/$.tsx
@@ -36,7 +36,7 @@ const deconstructPath = (
 
     if (isFlowSection(firstRoute) && isFlowContent(second)) {
       /* >> Start of custom landing pages >> */
-      if (second === "faq") {
+      if (second === "faq" && rest === "index") {
         return { secondRoute: second, path: "backers" }
       }
       /* << End of custom landing pages << */


### PR DESCRIPTION
This is a bug fix.

FAQ page was redirected to the first FAQ subpage manually. This should only happen for landing (mocking /index), not when the user redirects to other faq subpages.