### PR TITLE
Allow main layout to grow to full width

### DIFF
--- a/app/constants/repos/second-route-presets/cadence-language.json
+++ b/app/constants/repos/second-route-presets/cadence-language.json
@@ -6,7 +6,7 @@
         "title": "Cadence Language",
         "items": [
           { "href": "language/syntax", "label": "" },
-          { "href": "language/constants-and-variables", "label": ""},
+          { "href": "language/constants-and-variables", "label": "" },
           { "href": "language/type-annotations", "label": "" },
           { "href": "language/values-and-types", "label": "" },
           { "href": "language/operators", "label": "" },

--- a/app/ui/design-system/src/lib/Components/NavigationBar/DesktopMenuItem.tsx
+++ b/app/ui/design-system/src/lib/Components/NavigationBar/DesktopMenuItem.tsx
@@ -1,6 +1,7 @@
 import { Popover, Transition } from "@headlessui/react"
 import clsx from "clsx"
 import { Fragment } from "react"
+import { NAV_HEIGHT } from "."
 import { ReactComponent as ChevronDown } from "../../../../images/arrows/chevron-down"
 import { DesktopMenuTabbed } from "./DesktopMenuTabbed"
 import { MenuContent } from "./MenuContent"
@@ -61,7 +62,10 @@ export function DesktopMenuItem({ divider, ...props }: DesktopMenuItemProps) {
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <Popover.Panel className="fixed top-[90px] left-0 right-0 bottom-0 z-40 origin-top-right">
+            <Popover.Panel
+              className="fixed left-0 right-0 bottom-0 z-40 origin-top-right"
+              style={{ top: NAV_HEIGHT }}
+            >
               <div className="relative z-20 max-h-full">
                 {"tabs" in contentProps ? (
                   <DesktopMenuTabbed {...contentProps} />
@@ -69,7 +73,10 @@ export function DesktopMenuItem({ divider, ...props }: DesktopMenuItemProps) {
                   <MenuContent {...contentProps} />
                 )}
               </div>
-              <Popover.Overlay className="fixed top-[90px] left-0 right-0 bottom-0" />
+              <Popover.Overlay
+                className="fixed left-0 right-0 bottom-0"
+                style={{ top: NAV_HEIGHT }}
+              />
             </Popover.Panel>
           </Transition>
         </>

--- a/app/ui/design-system/src/lib/Components/NavigationBar/DesktopMenuItem.tsx
+++ b/app/ui/design-system/src/lib/Components/NavigationBar/DesktopMenuItem.tsx
@@ -61,7 +61,7 @@ export function DesktopMenuItem({ divider, ...props }: DesktopMenuItemProps) {
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <Popover.Panel className="fixed top-[96px] left-0 right-0 bottom-0 z-40 origin-top-right">
+            <Popover.Panel className="fixed top-[90px] left-0 right-0 bottom-0 z-40 origin-top-right">
               <div className="relative z-20 max-h-full">
                 {"tabs" in contentProps ? (
                   <DesktopMenuTabbed {...contentProps} />
@@ -69,7 +69,7 @@ export function DesktopMenuItem({ divider, ...props }: DesktopMenuItemProps) {
                   <MenuContent {...contentProps} />
                 )}
               </div>
-              <Popover.Overlay className="fixed top-[96px] left-0 right-0 bottom-0" />
+              <Popover.Overlay className="fixed top-[90px] left-0 right-0 bottom-0" />
             </Popover.Panel>
           </Transition>
         </>

--- a/app/ui/design-system/src/lib/Components/NavigationBar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/NavigationBar/index.tsx
@@ -14,7 +14,7 @@ export type NavigationBarProps = {
   onDarkModeToggle: () => void
 }
 
-export const NAV_HEIGHT = 96
+export const NAV_HEIGHT = 90
 
 export function NavigationBar({
   menuItems,
@@ -71,7 +71,10 @@ export function NavigationBar({
         leaveFrom="opacity-100 scale-100"
         leaveTo="opacity-0 scale-95"
       >
-        <div className="fixed top-[90px] left-0 right-0 bottom-0 z-40 origin-top-right overflow-auto bg-white dark:bg-black md:hidden">
+        <div
+          className="fixed left-0 right-0 bottom-0 z-40 origin-top-right overflow-auto bg-white dark:bg-black md:hidden"
+          style={{ top: NAV_HEIGHT }}
+        >
           <MobileMenu menuItems={menuItems} />
         </div>
       </Transition>

--- a/app/ui/design-system/src/lib/Components/NavigationBar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/NavigationBar/index.tsx
@@ -71,7 +71,7 @@ export function NavigationBar({
         leaveFrom="opacity-100 scale-100"
         leaveTo="opacity-0 scale-95"
       >
-        <div className="fixed top-[96px] left-0 right-0 bottom-0 z-40 origin-top-right overflow-auto bg-white dark:bg-black md:hidden">
+        <div className="fixed top-[90px] left-0 right-0 bottom-0 z-40 origin-top-right overflow-auto bg-white dark:bg-black md:hidden">
           <MobileMenu menuItems={menuItems} />
         </div>
       </Transition>

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -155,7 +155,7 @@ export function InternalPage({
           </>
         )}
         <main
-          className={clsx("flex max-w-full shrink grow-0 flex-row-reverse", {
+          className={clsx("flex max-w-full shrink-0 grow flex-row-reverse", {
             "md:max-w-[calc(100%_-_300px)]": sidebarConfig,
           })}
         >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -94,6 +94,7 @@ module.exports = {
       typography: (theme) => ({
         DEFAULT: {
           css: {
+            maxWidth: "unset",
             code: {
               borderRadius: theme("borderRadius.DEFAULT"),
               borderWidth: theme("borderWidth.DEFAULT"),


### PR DESCRIPTION
Fixes the main layout so it grows to the full width of the viewport.

Also tweaks the position of the main nav dropdowns - they were a little too low and allowed the top of the scrollbars for the main content to be visible.