### PR TITLE
Render tool menu in portal

### DIFF
--- a/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
@@ -1,5 +1,5 @@
-import { arrow, flip, useFloating } from "@floating-ui/react-dom"
-import { Popover } from "@headlessui/react"
+import { arrow, autoUpdate, flip, useFloating } from "@floating-ui/react-dom"
+import { Popover, Portal } from "@headlessui/react"
 import clsx from "clsx"
 import { useRef } from "react"
 import { ReactComponent as Close } from "../../../../images/action/close"
@@ -124,12 +124,17 @@ export function InternalSidebarMenu({
   const {
     x,
     y,
+    strategy,
     reference,
     floating,
     middlewareData: { arrow: { x: arrowX, y: arrowY } = {} },
   } = useFloating({
     middleware: [arrow({ element: arrowRef }), flip()],
     placement: "bottom-start",
+
+    // This is necessary because this menu may be hidden when it's first mounted
+    // (in the case of crossing mobile/desktop breakpoints)
+    whileElementsMounted: autoUpdate,
   })
   const SelectedIcon = TOOLS[selectedTool].icon
   return (
@@ -151,34 +156,36 @@ export function InternalSidebarMenu({
                 <ChevronDown />
               </div>
             </Popover.Button>
-            <div
-              className="absolute z-10 mt-8 w-screen px-4 md:min-w-[15rem]"
-              ref={floating}
-              style={{ top: y || 0, left: x || 0 }}
-            >
-              <DropdownTransition>
-                {/* fyi max-w-[34rem] is the intended full width here, using max-w-[18rem] since some entries are temporarily disabled */}
-                <Popover.Panel className="relative mr-2 min-w-[17rem] max-w-[18rem] overflow-y-auto rounded-lg bg-white px-4 py-2 shadow-2xl dark:bg-primary-gray-dark dark:shadow-2xl-dark dark:hover:shadow-2xl-dark dark:hover:shadow-2xl-dark md:px-6 md:py-4">
-                  {({ close }) =>
-                    SIDEBAR_SECTION_GROUPS.map((group, index) => (
-                      <SidebarSectionGroup
-                        group={group}
-                        index={index}
-                        key={index}
-                        close={close}
-                        toolLinks={toolLinks}
-                      />
-                    ))
-                  }
-                </Popover.Panel>
-              </DropdownTransition>
-              <DropdownArrow
-                arrowRef={arrowRef}
-                x={arrowX}
-                y={arrowY}
-                open={open}
-              />
-            </div>
+            <Portal>
+              <div
+                className="z-40 mt-8 w-screen px-4"
+                ref={floating}
+                style={{ top: y || 0, left: x || 0, position: strategy }}
+              >
+                <DropdownTransition>
+                  {/* fyi max-w-[34rem] is the intended full width here, using max-w-[18rem] since some entries are temporarily disabled */}
+                  <Popover.Panel className="relative mr-2 inline-block max-w-[18rem] overflow-y-auto rounded-lg bg-white px-4 py-2 shadow-2xl dark:bg-primary-gray-dark dark:shadow-2xl-dark dark:hover:shadow-2xl-dark dark:hover:shadow-2xl-dark md:px-6 md:py-4">
+                    {({ close }) =>
+                      SIDEBAR_SECTION_GROUPS.map((group, index) => (
+                        <SidebarSectionGroup
+                          group={group}
+                          index={index}
+                          key={index}
+                          close={close}
+                          toolLinks={toolLinks}
+                        />
+                      ))
+                    }
+                  </Popover.Panel>
+                </DropdownTransition>
+                <DropdownArrow
+                  arrowRef={arrowRef}
+                  x={arrowX}
+                  y={arrowY}
+                  open={open}
+                />
+              </div>
+            </Portal>
           </div>
         )}
       </Popover>


### PR DESCRIPTION
This partially fixes #395. In particular: 1) the menu was opening under the main content; and 2) it was scrolling horizontally.

The first issue is fixed by rendering the menu in a portal so it's in a stacking context that can be rendered above the main content.

The second issue is fixed by removing the min-width set on the container. 