### PR TITLE
Improve search results by redirecting /index internal pages to the canonical / path

### DIFF
--- a/app/routes/$repo/$.tsx
+++ b/app/routes/$repo/$.tsx
@@ -93,6 +93,10 @@ export const loader: LoaderFunction = async ({
   params,
   request,
 }): Promise<LoaderData> => {
+  if (params["*"]?.endsWith("index") && request.url.endsWith("/index")) {
+    throw redirect(request.url.replace(/\/index$/, "/"))
+  }
+
   const { firstRoute, secondRoute, path }: NestedRoute = deconstructPath(params)
 
   const contentSpec = getContentSpec(firstRoute, secondRoute)


### PR DESCRIPTION
removes duplicate search result entries for pages

```bash
❯ curl -I http://localhost:3000/tools/vscode-extension/index
HTTP/1.1 302 Found
location: http://localhost:3000/tools/vscode-extension/
Date: Fri, 08 Jul 2022 00:09:28 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```

after merging, visit https://crawler.algolia.com/admin/crawlers/2851150a-e19d-4969-b161-9a231619925f/overview and click "Restart crawling"