### PR TITLE
Add a robots.txt with algolia verification

### DIFF
--- a/app/routes/robots[.]txt.ts
+++ b/app/routes/robots[.]txt.ts
@@ -1,0 +1,26 @@
+import { LoaderFunction } from "@remix-run/node"
+import { getRequiredServerEnvVar } from "~/cms/helpers"
+
+export const loader: LoaderFunction = () => {
+  let origin: string = getRequiredServerEnvVar(
+    "ORIGIN",
+    `http://localhost:3000`
+  )
+
+  const sitemapUrl = new URL(`/sitemap.xml`, origin)
+
+  const robotsTxt = `# Algolia-Crawler-Verif: 98E1096D4FD67E70
+
+User-agent: *
+Allow: /
+Sitemap: ${sitemapUrl}
+`
+
+  return new Response(robotsTxt, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain",
+      encoding: "UTF-8",
+    },
+  })
+}


### PR DESCRIPTION
adds an id so algolia can verify the developers.onflow.org domain once this change is on production

1. visit https://crawler.algolia.com/admin/domains
1. click "Verify now" next to developers.onflow.org
1. visit https://crawler.algolia.com/admin/crawlers/c00d5208-dd7a-4573-9c64-3e35ece76d9d/configuration/edit
1. edit the algolia config and change the domains from the fly.dev ones to `https://developers.onflow.org/`
1. recrawl the site

e.g. change
```
startUrls: [
    "https://flow-docs.fly.dev/",
    "https://flow-docs-staging.fly.dev/",
  ],
```

to

```
startUrls: [
    "https://developers.onflow.org/",
  ],
```

and similarly for the actions.pathsToMatch field
