### PR TITLE
Cp/fix scroll to header

### DIFF
--- a/app/ui/design-system/src/lib/Components/Heading/index.tsx
+++ b/app/ui/design-system/src/lib/Components/Heading/index.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx"
-import React, { createElement } from "react"
+import { createElement } from "react"
 import LinkIcon from "./LinkIcon"
 
 type HeadingType = "h1" | "h2" | "h3" | "h4" | "h5" | "h6"

--- a/app/ui/design-system/src/lib/Components/Heading/index.tsx
+++ b/app/ui/design-system/src/lib/Components/Heading/index.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx"
-import { createElement } from "react"
+import React, { createElement } from "react"
 import LinkIcon from "./LinkIcon"
 
 type HeadingType = "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
@@ -25,14 +25,27 @@ function parameterize(string: string) {
     .replace(/ /g, "-")
 }
 
+function processChildren(children: any) {
+  return children.reduce((acc: string, curr: any) => {
+    if (typeof curr === "string") {
+      acc += curr
+    } else if (typeof curr === "object") {
+      acc += curr.props.children
+    }
+    return acc
+  }, "")
+}
+
 export function Heading({
   type = "h1",
   children,
   className,
   ...props
 }: HeadingProps) {
-  const text = typeof children === "string" ? children : ""
+  const text =
+    typeof children === "string" ? children : processChildren(children)
   const anchor = parameterize(text)
+
   return createElement(
     type,
     {

--- a/app/ui/design-system/src/lib/Components/Heading/index.tsx
+++ b/app/ui/design-system/src/lib/Components/Heading/index.tsx
@@ -21,7 +21,7 @@ const headingClasses = {
 function parameterize(string: string) {
   return string
     .toLowerCase()
-    .replace(/[^a-zA-Z0-9 ]/g, "")
+    .replace(/[^a-zA-Z0-9 -]/g, "")
     .replace(/ /g, "-")
 }
 


### PR DESCRIPTION
Closes #336 

Adjusted our `Header` component to accommodate headers with code blocks and hyphens.