### PR TITLE
Reroute Tool Switching

### DIFF
--- a/app/constants/repos/index.ts
+++ b/app/constants/repos/index.ts
@@ -38,7 +38,6 @@ import emulator from "./second-route-presets/emulator.json"
 import faq from "./second-route-presets/faq.json"
 
 import { populateRepoSchema, RepoSchema } from "./repo-schema"
-import { ToolName } from "../../ui/design-system/src/lib/Components/Internal/tools"
 import {
   ContentName,
   secondRoutes,
@@ -104,15 +103,6 @@ export const displayNames: Partial<Record<ContentName, string>> = {
   "nft-marketplace": "NFT Marketplace",
   fusd: "FUSD",
   faq: "FAQ",
-}
-
-export const contentTools: Partial<Record<ContentName, ToolName>> = {
-  cadence: "cadence",
-  "flow-cli": "cli",
-  emulator: "emulator",
-  "fcl-js": "fcl",
-  "flow-js-testing": "testing",
-  "vscode-extension": "vscode",
 }
 
 export type ContentSpec = {

--- a/app/ui/design-system/src/lib/Components/Internal/tools.ts
+++ b/app/ui/design-system/src/lib/Components/Internal/tools.ts
@@ -16,13 +16,13 @@ import { ReactComponent as VsCodeIcon } from "../../../../images/tools/tool-vsco
 import { ReactComponent as VsCodeGradientIcon } from "../../../../images/tools/tool-vscode-gradient"
 
 // TODO: iconLanding icons are placeholders until we have the assets
-
+// Keeping it consistent with path names
 export type ToolName =
   | "emulator"
-  | "vscode"
-  | "cli"
-  | "testing"
-  | "fcl"
+  | "vscode-extension"
+  | "flow-cli"
+  | "flow-js-testing"
+  | "fcl-js"
   | "cadence"
   | "flow-go-sdk"
   | "http-api"
@@ -30,7 +30,7 @@ export type ToolName =
   | "kitty-items"
   | "concepts"
   | "learn"
-  | "operation"
+  | "node-operation"
   | "staking"
   | "flow-port"
   | "nodes"
@@ -49,25 +49,25 @@ export const TOOLS: Record<ToolName, Tool> = {
     iconLanding: CadenceLandingIcon,
     gradientIcon: EmulatorGradientIcon,
   },
-  vscode: {
+  "vscode-extension": {
     name: "VS Code Extension",
     icon: VsCodeIcon,
     iconLanding: CadenceLandingIcon,
     gradientIcon: VsCodeGradientIcon,
   },
-  cli: {
+  "flow-cli": {
     name: "CLI",
     icon: CliIcon,
     iconLanding: CadenceLandingIcon,
     gradientIcon: CliGradientIcon,
   },
-  testing: {
+  "flow-js-testing": {
     name: "Testing Library",
     icon: TestingIcon,
     iconLanding: CadenceLandingIcon,
     gradientIcon: TestingGradientIcon,
   },
-  fcl: {
+  "fcl-js": {
     name: "Flow Client Library",
     icon: FclIcon,
     iconLanding: CadenceLandingIcon,
@@ -79,7 +79,6 @@ export const TOOLS: Record<ToolName, Tool> = {
     iconLanding: CadenceLandingIcon,
     gradientIcon: CadenceGradientIcon,
   },
-
   "flow-go-sdk": {
     name: "Go SDK",
     icon: DefaultIcon,
@@ -116,7 +115,7 @@ export const TOOLS: Record<ToolName, Tool> = {
     iconLanding: CadenceLandingIcon,
     gradientIcon: DefaultIcon,
   },
-  operation: {
+  "node-operation": {
     name: "Operation",
     icon: DefaultIcon,
     iconLanding: CadenceLandingIcon,

--- a/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
@@ -20,12 +20,12 @@ const SIDEBAR_SECTION_GROUPS: SectionGroup[] = [
   {
     name: "Switch tool",
     sections: [
-      "cli",
-      "fcl",
+      "flow-cli",
+      "fcl-js",
       "flow-go-sdk",
       "http-api",
       "emulator",
-      "vscode",
+      "vscode-extension",
       "tools",
     ],
   },
@@ -35,7 +35,7 @@ const SIDEBAR_SECTION_GROUPS: SectionGroup[] = [
   },
   {
     name: "Nodes",
-    sections: ["operation", "staking", "flow-port", "nodes"],
+    sections: ["node-operation", "staking", "flow-port", "nodes"],
   },
 ]
 


### PR DESCRIPTION
As we added more internal pages, there were inconsistent logic in routing to the right paths. Tools switching manually routed everything under /tools before, and that led to incorrect paths. This PR fixes this issue by using tool names as second routes, and mapping to the correct first paths when necessary.

<img width="1496" alt="Screen Shot 2022-07-08 at 6 54 25 PM" src="https://user-images.githubusercontent.com/18616121/178079673-9517be03-bfc6-484b-a436-d08f72550e00.png">
