### PR TITLE
Internal page minor fixes (2/3)

### DIFF
--- a/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
@@ -74,7 +74,8 @@ export function InternalSidebar({ config, menu }: InternalSidebarProps) {
           <div className="px-4">
             {section.items.map((item) => (
               <NavLink
-                to={item.href}
+                to={item.href === "index" ? "" : item.href} // allow `/index` pages to be highlighted without having `/index/` in path
+                end
                 key={item.label}
                 className={({ isActive }) =>
                   clsx(

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -92,7 +92,7 @@ export function InternalPage({
   useResizeObserver(subnavRef, resizeObserverCallback)
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col pb-16">
       <div className="sticky top-0 z-20" ref={subnavRef}>
         <InternalSubnav
           isSidebarOpen={isMobileSidebarOpen}


### PR DESCRIPTION
# Description
This PR fixes minor internal pages issues:
* Adds padding to the bottom of internal pages
* Fix highlighting index page on left menu

This pr has 2/3 internal page minor fixes. See https://github.com/onflow/next-docs-v1/issues/415#issuecomment-1180593891

![Screen Shot 2022-07-11 at 10 02 15 AM](https://user-images.githubusercontent.com/46465568/178307703-1e74c4c2-9622-4f8b-bcdc-4ad22a797385.png)
![Screen Shot 2022-07-11 at 10 03 04 AM](https://user-images.githubusercontent.com/46465568/178307716-f6cbc704-37c3-4d88-91b9-06bd5ee55ab5.png)
