### PR TITLE
Adjust secondary nav styles

### DIFF
--- a/app/ui/design-system/src/lib/Components/LandingPageSecondaryNav/index.tsx
+++ b/app/ui/design-system/src/lib/Components/LandingPageSecondaryNav/index.tsx
@@ -74,12 +74,12 @@ export function LandingPageSecondaryNav({
   }, [sections])
 
   return (
-    <div className="sticky top-0 z-10 hidden h-12 items-center justify-center gap-7 bg-[#30353E] py-3 px-1 text-white md:flex">
+    <div className="sticky top-0 z-10 hidden h-12 items-center justify-center gap-7 bg-black px-1 py-3 text-white dark:bg-primary-gray-dark md:flex">
       {sections.map(({ elementId, title }, i) => (
         <Link
           to={`#${elementId}`}
           className={clsx("px-1.5 py-1 line-clamp-1", {
-            "rounded-lg bg-gray-500": activeId === elementId,
+            "text-primary-purple": activeId === elementId,
           })}
           key={i}
         >


### PR DESCRIPTION
Addresses #415. Adjusts the active look of the secondary nav.

Light mode:
<img width="1327" alt="image" src="https://user-images.githubusercontent.com/17099857/178350429-6cdd04de-2e73-4834-8a76-e87ad5864d4f.png">

Dark mode:
<img width="1299" alt="image (1)" src="https://user-images.githubusercontent.com/17099857/178350440-e26d7e93-0206-4a49-8eaa-eec0d5dd29ea.png">

