### PR TITLE
Allow trusted repos that skip rehypeSanitize

### DIFF
--- a/app/cms/compile.mdx.server.ts
+++ b/app/cms/compile.mdx.server.ts
@@ -55,11 +55,17 @@ const remarkPlugins: U.PluggableList = [
   ],
 ]
 
-const rehypePlugins = (repoName: string): U.PluggableList => {
-  return [
+const rehypePlugins = (
+  repoName: string,
+  isTrusted: boolean = false
+): U.PluggableList => {
+  const plugins: U.PluggableList = [
     removePreContainerDivs,
     () => formatLinks(repoName),
-    [
+  ]
+
+  if (!isTrusted) {
+    plugins.push([
       rehypeSanitize,
       {
         ...defaultSchema,
@@ -74,13 +80,17 @@ const rehypePlugins = (repoName: string): U.PluggableList => {
           ],
         },
       },
-    ],
-  ]
+    ])
+  }
+
+  return plugins
 }
+
 async function compileMdx<FrontmatterType extends Record<string, unknown>>(
   slug: string,
   githubFiles: Array<GitHubFile>,
-  repoName: string
+  repoName: string,
+  isTrusted: boolean = false
 ) {
   const { default: remarkSlug } = await import("remark-slug")
   const { default: gfm } = await import("remark-gfm")
@@ -114,7 +124,7 @@ async function compileMdx<FrontmatterType extends Record<string, unknown>>(
         ]
         options.rehypePlugins = [
           ...(options.rehypePlugins ?? []),
-          ...rehypePlugins(repoName),
+          ...rehypePlugins(repoName, isTrusted),
         ]
 
         return options

--- a/app/cms/utils/mdx.tsx
+++ b/app/cms/utils/mdx.tsx
@@ -55,11 +55,13 @@ async function getMdxPage(
     repo,
     branch,
     fileOrDirPath,
+    isTrusted,
   }: {
     owner: string
     repo: string
     branch: string
     fileOrDirPath: string
+    isTrusted: boolean
   },
   options: CachifiedOptions
 ): Promise<MdxPage | null> {
@@ -87,6 +89,7 @@ async function getMdxPage(
         branch,
         fileOrDirPath,
         ...pageFiles,
+        isTrusted,
         options,
       }).catch((err) => {
         console.error(`Failed to get a fresh value for mdx:`, {
@@ -111,6 +114,7 @@ async function getMdxPagesInDirectory(
   repo: string,
   branch: string,
   fileOrDirPath: string,
+  isTrusted: boolean,
   options: CachifiedOptions
 ) {
   const dirList = await getMdxDirList(
@@ -145,6 +149,7 @@ async function getMdxPagesInDirectory(
         branch,
         fileOrDirPath,
         ...pageData,
+        isTrusted,
         options,
       })
     )
@@ -236,6 +241,7 @@ async function compileMdxCached({
   fileOrDirPath,
   entry,
   files,
+  isTrusted,
   options,
 }: {
   owner: string
@@ -244,6 +250,7 @@ async function compileMdxCached({
   fileOrDirPath: string
   entry: string
   files: Array<GitHubFile>
+  isTrusted: boolean
   options: CachifiedOptions
 }) {
   const key = getCompiledKey(owner, repo, branch, fileOrDirPath)
@@ -257,7 +264,8 @@ async function compileMdxCached({
       const compiledPage = await compileMdx<MdxPage["frontmatter"]>(
         fileOrDirPath,
         files,
-        repo
+        repo,
+        isTrusted
       )
       if (compiledPage) {
         return {

--- a/app/constants/repos/index.ts
+++ b/app/constants/repos/index.ts
@@ -135,6 +135,12 @@ export type ContentSpec = {
   displayName: string
   schema?: RepoSchema
   landingHeader?: InternalLandingHeaderProps
+
+  /**
+   * When true, the content will be considered "trusted" and will bypass
+   * the sanitization process.
+   */
+  isTrusted: boolean
 }
 
 function getBasePath(name: ContentName) {
@@ -160,6 +166,9 @@ const getRepoName = (name: ContentName) => {
 }
 
 const allRoutes: ContentName[] = [...FIRST_ROUTES, ...SECOND_ROUTES]
+
+const trustedRepositories = [...allRoutes]
+
 export const contentSpecMap = allRoutes.reduce(
   (accum, name) => ({
     ...accum,
@@ -172,6 +181,7 @@ export const contentSpecMap = allRoutes.reduce(
       displayName: displayNames[name] || capitalCase(name),
       schema: schemas[name],
       landingHeader: landingHeaders[name],
+      isTrusted: trustedRepositories.includes(name),
     },
   }),
   {} as Record<ContentName, ContentSpec>

--- a/app/routes/$repo/$.tsx
+++ b/app/routes/$repo/$.tsx
@@ -132,6 +132,7 @@ export const loader: LoaderFunction = async ({
         repo: contentSpec.repoName,
         branch: contentSpec.branch,
         fileOrDirPath: [contentSpec.basePath, path].join("/"),
+        isTrusted: contentSpec.isTrusted,
       },
       { request, forceFresh: process.env.FORCE_REFRESH === "true" }
     )

--- a/app/routes/action/refresh.tsx
+++ b/app/routes/action/refresh.tsx
@@ -88,6 +88,7 @@ export const action: ActionFunction = async ({ request }) => {
           owner: contentSpec.owner,
           repo: contentSpec.repoName,
           fileOrDirPath: contentPath,
+          isTrusted: contentSpec.isTrusted,
         },
         { forceFresh: true }
       )


### PR DESCRIPTION
Re-adds the `isTrusted` property to the `ContentSpec`s that was originally introduced by #387 but accidentally reverted.