### PR TITLE
Use singleton instance of slug generator

### DIFF
--- a/app/ui/design-system/src/lib/Components/Heading/index.tsx
+++ b/app/ui/design-system/src/lib/Components/Heading/index.tsx
@@ -20,8 +20,6 @@ const headingClasses = {
   h6: "text-sm",
 }
 
-const slugger = new GithubSlugger()
-
 export function Heading({
   type = "h1",
   children,
@@ -29,7 +27,7 @@ export function Heading({
   ...props
 }: HeadingProps) {
   const text = typeof children === "string" ? children : ""
-  const anchor = slugger.slug(text)
+  const anchor = GithubSlugger.slug(text)
 
   return createElement(
     type,


### PR DESCRIPTION
The slug generator that is use to generate anchors from headings keeps track of the slugs it generates and appends incrementing numbers when it finds duplicates. It's really meant to be run against a single page, in order, and then reset. 

But in react on the client-side we:
1. Can't guarantee the slugs are generated in the same order;
2. Can re-render, which causes the slugs to get ever-increasing suffixes appended. 

And since the table-of-contents used for the right sidebar gets generated separately and ahead of time, the anchors will no longer match. 

A singleton instance that doesn't track duplicates is also exported, so I'm using that here instead. As long as there are no duplicates it should work. I experimented with other ways of doing this, but ultimately the correct way is to make sure the slugs are exactly the same. But that will require a larger refactor effort. 