### PR TITLE
Add h1 to show in search results

### DIFF
--- a/app/ui/design-system/src/lib/Components/Search/Item.tsx
+++ b/app/ui/design-system/src/lib/Components/Search/Item.tsx
@@ -29,10 +29,16 @@ export function Item({ item, selected }: { item: HitType; selected: boolean }) {
           <Highlight hit={item} attribute="title" />
         </div>
         <Snippet
-          attribute="content"
+          attribute="headers"
           // @ts-expect-error: TODO: Short description of the error
           hit={item}
           className="break-all text-primary-gray-300 dark:text-primary-gray-200"
+        />
+        <Snippet
+          attribute="content"
+          // @ts-expect-error: TODO: Short description of the error
+          hit={item}
+          className="break-all text-primary-gray-200 dark:text-primary-gray-200"
         />
       </div>
       <div className="ml-auto">


### PR DESCRIPTION
The search results displays only 'title' but not 'h1' which often is the true title of the page. Algolia doesn't return 'h0/h1' separately, but in a list of headers. We're extracting headers[1] for displaying h1s.

Other changes NOT in code but in Algolia Settings:
- We can order the searchable attributes to the order of importance we want. This will get us better results showing at the top. The new order is:
1. title, 2. headers, 3. content, 4. keywords
see link here: https://www.algolia.com/apps/DKF9ZIO5WM/explorer/configuration/crawler_Flow%20Docs%20Staging/searchable-attributes

Todo:

- [x] Show h1 as a part of highlighted
- [ ] Remove duplicate routes like /cadence, /cadence/

When searching "Introduction to Cadence"
Before:
![Screen Shot 2022-07-22 at 11 02 15 AM](https://user-images.githubusercontent.com/18616121/180476208-4ef0f02c-7a8f-45af-b620-b00935b6482f.png)

After:
<img width="1512" alt="Screen Shot 2022-07-22 at 1 33 54 PM" src="https://user-images.githubusercontent.com/18616121/180493746-fca15f20-82ee-47d5-bec1-3fedf9b6c7d1.png">


