### PR TITLE
Dockerize full development environment

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM node:16
+
+WORKDIR /opt/next-docs
+COPY package.json yarn.lock ./
+RUN yarn
+COPY . .
+
+CMD ["yarn", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -17,18 +17,20 @@ git clone https://github.com/onflow/next-docs-v1.git
 
 You'll need to acquire the project's `.env` file before continuing.
 
-- Add the `.env` file to `/apps/flow-docs/.env`
+1. Add the `.env` file to the project root.
+2. `docker compose up`
 
-1. `yarn`
-2. `docker compose up -d` To start Redis and Postgres for the project. (use this when not running Postgres & Redis from your system)
+Main application: http://localhost:3000/
+Storybook: http://localhost:6006/
 
-### Running Storybook
+#### Running services locally outside of Docker
 
-1. `yarn storybook`
-
-### Running the Docs Site
-
-1. `yarn dev`
+1. Add the `.env` file to the project root.
+2. `yarn`
+3. `docker compose up -d` To start Redis and Postgres for the project. (use this when not running Postgres & Redis from your system)
+4. Run the desired application:
+   - `yarn run dev` to run the Docs Site (https://localhost:3000)
+   - `yarn storybook` to run Storybook (https://localhost:6006)
 
 # Development
 

--- a/app/ui/design-system/src/lib/Components/UpcomingEvents/UpcomingEvents.stories.tsx
+++ b/app/ui/design-system/src/lib/Components/UpcomingEvents/UpcomingEvents.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, Story } from "@storybook/react"
-import { OFFICE_HOURS_EVENT_TYPE } from "~/component-data/Events"
 import { UpcomingEvents, UpcomingEventsProps } from "."
+
+export const OFFICE_HOURS_EVENT_TYPE = "Flow office hours"
 
 export default {
   component: UpcomingEvents,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,79 @@
-version: "3.7"
+version: "3.8"
+
+networks:
+  next-docs-net:
+
+volumes:
+  node_modules:
+  postgres_data:
+  redis_data:
+
+# Default for all services
+x-service-defaults: &service-defaults
+  restart: unless-stopped
+  networks:
+    - next-docs-net
+
+# Defaults for all app-based node services
+x-app-defaults: &app-defaults
+  <<: *service-defaults
+  build:
+    context: .
+    dockerfile: Dockerfile.dev
+  command: ["yarn"]
+  working_dir: /opt/next-docs
+  depends_on:
+    - database
+    - cache
+  restart: on-failure
+  environment:
+    DATABASE_URL: postgresql://flow_docs_user:flow_docs_pass@database:5432/flow_docs_db?schema=public
+    REDIS_URL: redis://:flow_docs@cache:6379
+    REFRESH_CACHE_SECRET: for-testing-only
+    INCOMPLETE_PAGE_BEHAVIORL: preview
+    SENTRY_ENV: sentry-development
+    SHELL: /bin/bash
+    PORT: 3000
+    REMIX_DEV_SERVER_WS_PORT: 8002
+  volumes:
+    - type: bind
+      source: .
+      target: /opt/next-docs
+    - node_modules:/opt/next-docs/node_modules
+
 services:
   database:
+    <<: *service-defaults
     image: "postgres:13"
     environment:
-      - POSTGRES_USER=flow_docs_user
-      - POSTGRES_PASSWORD=flow_docs_pass
-      - POSTGRES_DB=flow_docs_db
+      POSTGRES_USER: flow_docs_user
+      POSTGRES_PASSWORD: flow_docs_pass
+      POSTGRES_DB: flow_docs_db
     volumes:
-      - .postgres-data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
+      - postgres_data:/var/lib/postgresql
   cache:
+    <<: *service-defaults
     image: "redis:alpine"
     command: redis-server --requirepass flow_docs
     volumes:
-      - .redis-data:/data
+      - redis_data:/data
+  app-css:
+    <<: *app-defaults
+    command: ["yarn", "run", "dev:css"]
+  app-svg:
+    <<: *app-defaults
+    command: ["yarn", "run", "dev:svg"]
+  app:
+    <<: *app-defaults
+    command: ["yarn", "run", "dev:remix"]
     ports:
-      - "6379:6379"
+      - "3000:3000" # Web app port
+      - "8002:8002" # Websocket for live-reload
+    depends_on:
+      - app-css
+      - app-svg
+  storybook:
+    <<: *app-defaults
+    command: ["yarn", "run", "start-storybook", "-p", "6006", "--quiet", "--no-open", "--disable-telemetry"]
+    ports:
+      - "6006:6006"


### PR DESCRIPTION
This adds the entire app to the `docker-compose.yml` so that a full development environment can be brought up with a single `docker compose up`. It starts the Docs Site on port 3000 and Storybook on port 6006 to maintain the same behavior we currently have. 

This should also fix the issues some of us have been having where `yarn dev` doesn't rebuild correctly and leaves a hanging node process, necessitating restarting the app and manually killing any node instances (it doesn't use `run-p`, instead watching for CSS/SVG changes in separate docker containers).

Hoping everyone is cool with this. It should make getting things up-and-running for new folks much easier, and helps a lot when switching between other projects.