### PR TITLE
Remove postgres from docker config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Storybook: http://localhost:6006/
 
 1. Add the `.env` file to the project root.
 2. `yarn`
-3. `docker compose up -d` To start Redis and Postgres for the project. (use this when not running Postgres & Redis from your system)
+3. (Optional, if redis is not running locally) Start a redis instance: `docker run -v redis_data:/data -p 6379:6379 --name flowdocs-cache -d redis:alpine redis-server --requirepass flow_docs`
 4. Run the desired application:
    - `yarn run dev` to run the Docs Site (https://localhost:3000)
    - `yarn storybook` to run Storybook (https://localhost:6006)

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -6,7 +6,6 @@ function getEnv() {
     BOT_GITHUB_TOKEN: process.env.BOT_GITHUB_TOKEN,
     BOT_DISCORD_TOKEN: process.env.BOT_DISCORD_TOKEN,
     SESSION_SECRET: process.env.SESSION_SECRET,
-    DATABASE_URL: process.env.DATABASE_URL,
     REDIS_URL: process.env.REDIS_URL,
     REDIS_CA: process.env.REDIS_CA,
     REFRESH_CACHE_SECRET: process.env.REFRESH_CACHE_SECRET,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ networks:
 
 volumes:
   node_modules:
-  postgres_data:
   redis_data:
 
 # Default for all services
@@ -27,7 +26,6 @@ x-app-defaults: &app-defaults
     - cache
   restart: on-failure
   environment:
-    DATABASE_URL: postgresql://flow_docs_user:flow_docs_pass@database:5432/flow_docs_db?schema=public
     REDIS_URL: redis://:flow_docs@cache:6379
     REFRESH_CACHE_SECRET: for-testing-only
     INCOMPLETE_PAGE_BEHAVIORL: preview
@@ -42,15 +40,6 @@ x-app-defaults: &app-defaults
     - node_modules:/opt/next-docs/node_modules
 
 services:
-  database:
-    <<: *service-defaults
-    image: "postgres:13"
-    environment:
-      POSTGRES_USER: flow_docs_user
-      POSTGRES_PASSWORD: flow_docs_pass
-      POSTGRES_DB: flow_docs_db
-    volumes:
-      - postgres_data:/var/lib/postgresql
   cache:
     <<: *service-defaults
     image: "redis:alpine"


### PR DESCRIPTION
Removes postgres from the docker services and removes the `POSTGRES_URL` environment variable since the app doesn't use postgres.