### PR TITLE
Show selector on flow page

### DIFF
--- a/app/routes/$repo/$.tsx
+++ b/app/routes/$repo/$.tsx
@@ -156,9 +156,9 @@ export default function RepoDocument() {
   //
   // Logically a tool is NOT included in the list of flow routes (routes with the parent /flow)
   // const tool = ![...ROUTING_STRUCTURE.flow].includes(content.contentName)
-  const isSwitchContent = Object.keys(switchContents).includes(
-    content.contentName
-  )
+  const isSwitchContent =
+    Object.keys(switchContents).includes(content.contentName) ||
+    content.contentName === "flow"
 
   return (
     <InternalPage

--- a/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebarMenu/index.tsx
@@ -107,7 +107,8 @@ export function InternalSidebarMenu({
     whileElementsMounted: autoUpdate,
   })
 
-  const SelectedIcon = switchContents[selectedTool]!.icon
+  const SelectedIcon = switchContents[selectedTool]?.icon
+  const toolName = switchContents[selectedTool]?.name
 
   return (
     <div>
@@ -119,10 +120,10 @@ export function InternalSidebarMenu({
               className="mb-4 flex min-w-[210px] items-center rounded-lg p-2 pr-3 text-sm shadow-2xl hover:text-primary-gray-300 dark:bg-black dark:text-primary-gray-200 dark:shadow-2xl-dark-strong dark:hover:text-primary-gray-100"
             >
               <div className="mr-2 h-8 w-8">
-                <SelectedIcon />
+                {SelectedIcon && <SelectedIcon />}
               </div>
               <div className="text-small font-bold">
-                {switchContents[selectedTool]?.name}
+                {toolName ? toolName : "Find a guide"}
               </div>
               <div className="ml-auto pl-2">
                 <ChevronDown />


### PR DESCRIPTION
Closes #453 

The switcher already showed up on the `/nodes` page so this just addresses `/flow`. I have default text that I just chose to show as an example. Happy to update it to whatever would be most user friendly.

![image](https://user-images.githubusercontent.com/17099857/181641731-f90bd03d-5f0e-4b5f-9f50-21fffd85b92a.png)
