### PR TITLE
feat: add wallets section to tools page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ git clone https://github.com/onflow/next-docs-v1.git
 You'll need to acquire the project's `.env` file before continuing.
 
 1. Add the `.env` file to the project root.
-2. `docker compose up`
+2. `yarn build`
+3. `docker compose up`
 
 Main application: http://localhost:3000/
 Storybook: http://localhost:6006/

--- a/app/component-data/NavigationBar/documentationTabData.tsx
+++ b/app/component-data/NavigationBar/documentationTabData.tsx
@@ -70,6 +70,10 @@ export const toolsSection: Section = {
       href: "https://github.com/onflow/fcl-dev-wallet",
     },
     {
+      title: "Flow Wallets",
+      href: "/flow/flow-token/available-wallets",
+    },
+    {
       title: "Event Indexer",
       href: "https://github.com/rayvin-flow/flow-scanner",
     },

--- a/app/component-data/Tools/index.tsx
+++ b/app/component-data/Tools/index.tsx
@@ -381,6 +381,51 @@ const flowPortTool = {
   description: "Your portal to the decentralized world of Flow.",
 }
 
+const dapperWallet = {
+  title: "Dapper Wallet",
+  tags: ["web", "wallet", "custodial"],
+  link: "https://www.meetdapper.com/",
+  iconSrc:
+    "https://assets.website-files.com/60796227183fcb19c208916e/611ac35ed3af7095b0e0deee_Dapper.png",
+  description:
+    "Easy and securely buy and store digital assets from groundbreaking Flow apps and games",
+}
+
+const bloctoWallet = {
+  title: "Blocto",
+  tags: ["web", "android", "ios", "wallet", "custodial"],
+  link: "https://blocto.portto.io/en/",
+  iconSrc: "https://token.blocto.app/img/logo.png",
+  description:
+    "Manage your crypto, dApps, and NFT all-in-once through Blocto, the cross-chain crypto wallet",
+}
+
+const ledgerWallet = {
+  title: "Ledger",
+  tags: ["hardware", "wallet", "non-custodial"],
+  link: "https://www.ledger.com/",
+  iconSrc:
+    "https://www.ledger.com/wp-content/uploads/2021/11/Ledger_favicon.png",
+  description:
+    "The hardware wallet to secure, buy, exchange, and grow your crypto assets",
+}
+
+const lilicoWallet = {
+  title: "Lilico",
+  tags: ["web", "extension", "wallet", "non-custodial"],
+  link: "https://lilico.app/",
+  iconSrc: "https://lilico.app/logo-cat.svg",
+  description: "The First Extension Wallet on Flow",
+}
+
+const fionaWallet = {
+  title: "Finoa",
+  tags: ["institutional", "wallet", "custodial"],
+  link: "https://www.finoa.io/flow/",
+  iconSrc: "https://www.finoa.io/icons/icon-512x512.png?v=1659609128276",
+  description: "Safely store and stake your Flow tokens with Finoa",
+}
+
 export {
   flowserTool,
   overflowTool,
@@ -416,4 +461,9 @@ export {
   cdcWebpackPlugin,
   graffleTool,
   flowPortTool,
+  bloctoWallet,
+  dapperWallet,
+  ledgerWallet,
+  lilicoWallet,
+  fionaWallet,
 }

--- a/app/constants/landingPages/toolsSections.ts
+++ b/app/constants/landingPages/toolsSections.ts
@@ -1,5 +1,6 @@
 export const toolsSections = [
   { title: "Development Tools", elementId: "development-tools" },
+  { title: "Wallets", elementId: "wallets" },
   { title: "SDKs", elementId: "sdks" },
   { title: "APIs and Services", elementId: "apis-and-services" },
   {

--- a/app/routes/tools/data.ts
+++ b/app/routes/tools/data.ts
@@ -34,6 +34,11 @@ import {
   graffleTool,
   commandLineLinter,
   cdcWebpackPlugin,
+  bloctoWallet,
+  dapperWallet,
+  ledgerWallet,
+  lilicoWallet,
+  fionaWallet,
 } from "../../component-data/Tools"
 
 export const data: ToolsPageProps = {
@@ -50,6 +55,13 @@ export const data: ToolsPageProps = {
     commandLineLinter,
     cdcWebpackPlugin,
     graffleTool,
+  ],
+  wallets: [
+    bloctoWallet,
+    dapperWallet,
+    ledgerWallet,
+    lilicoWallet,
+    fionaWallet,
   ],
   sdks: [
     httpSDK,

--- a/app/routes/tools/index.tsx
+++ b/app/routes/tools/index.tsx
@@ -16,6 +16,7 @@ export default function Page() {
       contentNavigationListItems={data.contentNavigationListItems}
       sdks={data.sdks}
       tools={data.tools}
+      wallets={data.wallets}
     />
   )
 }

--- a/app/ui/design-system/src/lib/Pages/ToolsPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/ToolsPage/index.tsx
@@ -15,6 +15,7 @@ import { toolsSections } from "~/constants/landingPages/toolsSections"
 export type ToolsPageProps = {
   editPageUrl?: string
   tools: SDKCardProps[]
+  wallets: SDKCardProps[]
   sdks: SDKCardProps[]
   explorers: SDKCardProps[]
   apisAndServices: SDKCardProps[]
@@ -24,6 +25,7 @@ export type ToolsPageProps = {
 const ToolsPage = ({
   editPageUrl,
   tools,
+  wallets,
   sdks,
   explorers,
   apisAndServices,
@@ -50,6 +52,14 @@ const ToolsPage = ({
             headerLink="development-tools"
             cards={tools}
             description="These essential tools will help you build, test, and debug your dapp on Flow."
+          />
+        </PageSection>
+        <PageSection sectionId="wallets">
+          <SDKCards
+            header="Wallets"
+            headerLink="wallets"
+            cards={wallets}
+            description="Integrate with these wallets to help your users onboard to Flow and manage their Flow accounts."
           />
         </PageSection>
         <PageSection sectionId="sdks">


### PR DESCRIPTION
Added a "Wallets" section to the tools page:

<img width="1488" alt="Screen Shot 2022-08-08 at 10 14 03 PM" src="https://user-images.githubusercontent.com/97620081/183569759-d86f7b9b-5919-40c6-8133-93a5554f33c1.png">

Added a "Flow Wallets" link to the nav:

<img width="1499" alt="Screen Shot 2022-08-08 at 10 19 42 PM" src="https://user-images.githubusercontent.com/97620081/183570544-57a33afa-45bc-4494-8484-61ab52f342c9.png">

