### PR TITLE
Adds additional breadcrumbs

### DIFF
--- a/app/constants/sidebar-dropdown-menu.ts
+++ b/app/constants/sidebar-dropdown-menu.ts
@@ -1,0 +1,62 @@
+import { InternaSidebarDropdownMenuGroup } from "../ui/design-system/src/lib/Components/InternalSidebarDropdownMenu"
+
+export const SIDEBAR_DROPDOWN_MENU: InternaSidebarDropdownMenuGroup[] = [
+  {
+    title: "Tools",
+    items: [
+      { title: "CLI", href: "/tools/flow-cli", icon: "flow-cli" },
+      {
+        title: "Flow Client Library",
+        href: "/tools/fcl-js",
+        icon: "fcl-js",
+      },
+      {
+        title: "Go SDK",
+        href: "/tools/flow-go-sdk",
+        icon: "default",
+      },
+      { title: "HTTP API", href: "/http-api", icon: "default" },
+      { title: "Emulator", href: "/tools/emulator", icon: "emulator" },
+      {
+        title: "VS Code Extension",
+        href: "/tools/vscode-extension",
+        icon: "vscode-extension",
+      },
+      { title: "All tools", href: "/tools", icon: "default" },
+    ],
+  },
+  {
+    title: "Learn",
+    items: [
+      { title: "Cadence", href: "/cadence", icon: "cadence" },
+      {
+        title: "Kitty Items",
+        href: "/learn/kitty-items",
+        icon: "default",
+      },
+      {
+        title: "Concepts & Guides",
+        href: "/learn/concepts",
+        icon: "default",
+      },
+      { title: "All content", href: "/learn", icon: "default" },
+    ],
+  },
+  {
+    title: "Nodes",
+    items: [
+      {
+        title: "Operation",
+        href: "/nodes/node-operation",
+        icon: "default",
+      },
+      { title: "Staking", href: "/nodes/staking", icon: "default" },
+      {
+        title: "Flow Port",
+        href: "/nodes/flow-port",
+        icon: "flow-port",
+      },
+      { title: "Flow Nodes", href: "/nodes", icon: "default" },
+    ],
+  },
+]

--- a/app/routes/__docs/$/$.tsx
+++ b/app/routes/__docs/$/$.tsx
@@ -95,6 +95,12 @@ export default () => {
   return (
     <InternalUrlContext.Provider value={pageBasePath}>
       <InternalPage
+        additionalBreadrumbs={[
+          { href: "/flow", title: "Flow" },
+          { href: "/learn", title: "Learn" },
+          { href: "/nodes", title: "Nodes" },
+          { href: "/tools", title: "Tools" },
+        ]}
         collectionDisplayName={data.displayName}
         collectionRootPath={data.collectionRootPath}
         header={data.header}

--- a/app/routes/__docs/$/$.tsx
+++ b/app/routes/__docs/$/$.tsx
@@ -5,8 +5,10 @@ import { MdxPage } from "../../../cms"
 import { NotFoundError } from "../../../cms/errors/not-found-error"
 import { getMdxPage, useMdxComponent } from "../../../cms/utils/mdx"
 import { findCollection } from "../../../constants/collections.server"
+import { SIDEBAR_DROPDOWN_MENU } from "../../../constants/sidebar-dropdown-menu"
 import AppLink from "../../../ui/design-system/src/lib/Components/AppLink"
 import { ErrorPage } from "../../../ui/design-system/src/lib/Components/ErrorPage"
+import { InternaSidebarDropdownMenuGroup } from "../../../ui/design-system/src/lib/Components/InternalSidebarDropdownMenu"
 import { InternalUrlContext } from "../../../ui/design-system/src/lib/Components/InternalUrlContext"
 import { InternalPage } from "../../../ui/design-system/src/lib/Pages/InternalPage"
 import logger from "../../../utils/logging.server"
@@ -16,6 +18,7 @@ type LoaderData = {
   page: MdxPage
   data: NonNullable<ReturnType<typeof findCollection>>
   pageBasePath: string
+  sidebarDropdownMenu: InternaSidebarDropdownMenuGroup[]
 }
 
 export const loader: LoaderFunction = async ({ params, request }) => {
@@ -51,7 +54,12 @@ export const loader: LoaderFunction = async ({ params, request }) => {
     )
     const pageBasePath = nodePath.posix.dirname(path) + "/"
 
-    return json({ data, page, pageBasePath })
+    return json({
+      data,
+      page,
+      pageBasePath,
+      sidebarDropdownMenu: SIDEBAR_DROPDOWN_MENU,
+    })
   } catch (e) {
     if (e instanceof NotFoundError) {
       throw json({ status: "noPage" }, { status: 404 })
@@ -77,7 +85,8 @@ export const meta: MetaFunction = ({ data, location }) => {
 }
 
 export default () => {
-  const { data, page, pageBasePath } = useLoaderData<LoaderData>()
+  const { data, page, pageBasePath, sidebarDropdownMenu } =
+    useLoaderData<LoaderData>()
   const MDXContent = useMdxComponent(page)
 
   // TODO: extract sidebarDropdownMenu and put in "constants" or somehwere
@@ -90,66 +99,7 @@ export default () => {
         collectionRootPath={data.collectionRootPath}
         header={data.header}
         sidebarItems={data.sidebar}
-        sidebarDropdownMenu={[
-          {
-            title: "Tools",
-            items: [
-              { title: "CLI", href: "/tools/flow-cli", icon: "flow-cli" },
-              {
-                title: "Flow Client Library",
-                href: "/tools/fcl-js",
-                icon: "fcl-js",
-              },
-              {
-                title: "Go SDK",
-                href: "/tools/flow-go-sdk",
-                icon: "default",
-              },
-              { title: "HTTP API", href: "/http-api", icon: "default" },
-              { title: "Emulator", href: "/tools/emulator", icon: "emulator" },
-              {
-                title: "VS Code Extension",
-                href: "/tools/vscode-extension",
-                icon: "vscode-extension",
-              },
-              { title: "All tools", href: "/tools", icon: "default" },
-            ],
-          },
-          {
-            title: "Learn",
-            items: [
-              { title: "Cadence", href: "/cadence", icon: "cadence" },
-              {
-                title: "Kitty Items",
-                href: "/learn/kitty-items",
-                icon: "default",
-              },
-              {
-                title: "Concepts & Guides",
-                href: "/learn/concepts",
-                icon: "default",
-              },
-              { title: "All content", href: "/learn", icon: "default" },
-            ],
-          },
-          {
-            title: "Nodes",
-            items: [
-              {
-                title: "Operation",
-                href: "/nodes/node-operation",
-                icon: "default",
-              },
-              { title: "Staking", href: "/nodes/staking", icon: "default" },
-              {
-                title: "Flow Port",
-                href: "/nodes/flow-port",
-                icon: "flow-port",
-              },
-              { title: "Flow Nodes", href: "/nodes", icon: "default" },
-            ],
-          },
-        ]}
+        sidebarDropdownMenu={sidebarDropdownMenu}
         editPageUrl={page.origin.html_url || undefined}
         toc={page.toc}
       >

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -81,13 +81,12 @@ export function InternalPage({
   useEffect(() => {
     if (contentRef.current && !header) {
       // Only scroll on pages without a header.
-      console.log("scrollin'")
-      contentRef.current.scrollIntoView({ block: "start" })
+      contentRef.current.scrollIntoView(true)
     }
   }, [pathname, header])
 
   return (
-    <div className="flex flex-col pb-16">
+    <div className="flex flex-col pb-16" ref={contentRef}>
       <div className="sticky top-0 z-20 bg-white dark:bg-black" ref={subnavRef}>
         <InternalSubnav
           isSidebarOpen={isMobileSidebarOpen}
@@ -146,13 +145,9 @@ export function InternalPage({
           </>
         )}
         <main
-          className={clsx(
-            "scroll-offset flex max-w-full shrink-0 grow flex-row-reverse",
-            {
-              "md:max-w-[calc(100%_-_300px)]": sidebarItems,
-            }
-          )}
-          ref={contentRef}
+          className={clsx("flex max-w-full shrink-0 grow flex-row-reverse", {
+            "md:max-w-[calc(100%_-_300px)]": sidebarItems,
+          })}
         >
           {toc && (
             <div className="hidden flex-none md:flex md:w-1/4">

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -21,9 +21,14 @@ import {
   useResizeObserver,
   UseResizeObserverCallback,
 } from "../../utils/useResizeObserver"
-import { useInternalBreadcrumbs } from "./useInternalBreadcrumbs"
+import {
+  useInternalBreadcrumbs,
+  UseInternalBreadcrumbsOptions,
+} from "./useInternalBreadcrumbs"
 
 export type InternalPageProps = React.PropsWithChildren<{
+  additionalBreadrumbs?: UseInternalBreadcrumbsOptions["additionalitems"]
+
   /**
    * THe name to display in the breadcrumbs for the current collection
    */
@@ -50,7 +55,9 @@ export type InternalPageProps = React.PropsWithChildren<{
 
   toc?: InternalTocItem[]
 }>
+
 export function InternalPage({
+  additionalBreadrumbs,
   children,
   collectionDisplayName,
   collectionRootPath,
@@ -64,6 +71,7 @@ export function InternalPage({
   const { previous, active, next } = useActiveSidebarItems(sidebarItems || [])
   const breadcrumbs = useInternalBreadcrumbs({
     activeItem: active,
+    additionalitems: additionalBreadrumbs,
     collectionDisplayName,
     collectionRootPath,
   })

--- a/app/ui/design-system/src/lib/Pages/InternalPage/useInternalBreadcrumbs.ts
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/useInternalBreadcrumbs.ts
@@ -5,9 +5,18 @@ export type UseInternalBreadcrumbsOptions = {
    * The currently active item taken from the sidebar configuration object.
    */
   activeItem?: {
-    title: string
     href: string
+    title: string
   }
+
+  /**
+   * An array of additional possible breadcrumnbs. If any match the
+   * `activeItem` they will be included.
+   */
+  additionalitems?: Array<{
+    href: string
+    title: string
+  }>
 
   /**
    * THe name to display in the breadcrumbs for the current collection
@@ -26,6 +35,7 @@ export type UseInternalBreadcrumbsOptions = {
  */
 export const useInternalBreadcrumbs = ({
   activeItem,
+  additionalitems,
   collectionDisplayName,
   collectionRootPath,
 }: UseInternalBreadcrumbsOptions) =>
@@ -35,9 +45,19 @@ export const useInternalBreadcrumbs = ({
       { href: collectionRootPath, title: collectionDisplayName },
     ]
 
+    // Add any additional items that match the active item.
+    additionalitems?.forEach((item) => {
+      if (activeItem?.href?.startsWith(item.href)) {
+        breadcrumbs.push(item)
+      }
+    })
+
+    // Make sure items are sorted from least-specific to most-specific
+    breadcrumbs.sort((a, b) => a.href.length - b.href.length)
+
     if (activeItem) {
       breadcrumbs.push(activeItem)
     }
 
     return breadcrumbs
-  }, [activeItem, collectionDisplayName, collectionRootPath])
+  }, [activeItem, additionalitems, collectionDisplayName, collectionRootPath])


### PR DESCRIPTION
Adds additional breadcrumbs for "Flow", "Tools", "Learn", and "Nodes" parent pages. 

Additionally:
- Fixes the scrolling issue when changing pages that wasn't quite scrolling to the top of the page 
- Moves the sidebar dropdown menu configuration into a separate file.

Fixes #518, Fixes #522 
