### PR TITLE
Ignore/redirect trailing slashes

### DIFF
--- a/app/routes/__docs/$.tsx
+++ b/app/routes/__docs/$.tsx
@@ -1,5 +1,7 @@
+import { join } from "path"
 import { json, LoaderFunction, redirect } from "@remix-run/node"
 import { Outlet, useLoaderData } from "@remix-run/react"
+import { stripTrailingSlahes } from "../../cms/utils/strip-slashes"
 import { findCollection } from "../../constants/collections.server"
 import { SidebarItem } from "../../ui/design-system/src/lib/Components/InternalSidebar"
 import { InternalSidebarUrlContext } from "../../ui/design-system/src/lib/Components/InternalSidebar/InternalSidebarUrlContext"
@@ -11,6 +13,11 @@ type LoaderData = {
 
 export const loader: LoaderFunction = async ({ params, request }) => {
   const path = params["*"]
+
+  if (path?.endsWith("/")) {
+    // For consistency, strip trailing slashes from all URLs.
+    return redirect(join("/", stripTrailingSlahes(path)), 302)
+  }
 
   if (!path) {
     throw json({ status: "noPage" }, { status: 404 })

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
@@ -21,6 +21,10 @@ export interface SidebarLinkItem extends SidebarItemBase {
 
 export type SidebarItem = SidebarHeadingItem | SidebarLinkItem
 
+export function isSidebarLinkItem(item: SidebarItem): item is SidebarLinkItem {
+  return "href" in item
+}
+
 export type InternalSidebarProps = {
   items: SidebarItem[]
   menu?: InternaSidebarDropdownMenuGroup[]
@@ -51,7 +55,7 @@ const InternalSidebarLinkItem = ({ item }: { item: SidebarLinkItem }) => {
 
 const InternalSidebarItem = ({ item }: { item: SidebarItem }) => (
   <>
-    {"href" in item ? (
+    {isSidebarLinkItem(item) ? (
       <InternalSidebarLinkItem item={item} />
     ) : (
       <div className="mb-4 text-xs uppercase text-gray-500 dark:text-gray-200">

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/useActiveSidebarItems.ts
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/useActiveSidebarItems.ts
@@ -1,6 +1,7 @@
 import { useLocation } from "@remix-run/react"
 import { useContext } from "react"
-import { SidebarItem, SidebarLinkItem } from "."
+import { isSidebarLinkItem, SidebarItem, SidebarLinkItem } from "."
+import { stripTrailingSlahes } from "../../utils/stripTrailingSlahes"
 import { titleFromHref } from "../../utils/titleFromHref"
 import { InternalSidebarUrlContext } from "./InternalSidebarUrlContext"
 
@@ -15,21 +16,19 @@ export const flattenItems = (items?: SidebarItem[]): SidebarItem[] =>
  * relative to the active item.
  */
 export const useActiveSidebarItems = (items: SidebarItem[]) => {
-  const { pathname } = useLocation()
+  const location = useLocation()
+  const path = stripTrailingSlahes(location.pathname)
   const sidebarBasePath = useContext(InternalSidebarUrlContext)
 
-  const linkItems = flattenItems(items).filter(
-    (item) => "href" in item
-  ) as SidebarLinkItem[]
+  const linkItems =
+    flattenItems(items).filter<SidebarLinkItem>(isSidebarLinkItem)
 
   const resolvedLinkItems = linkItems.map((item) => ({
-    href: `${sidebarBasePath}${item.href}`,
+    href: stripTrailingSlahes(`${sidebarBasePath}${item.href}`),
     title: item.title || titleFromHref(item.href),
   }))
 
-  const activeIndex = resolvedLinkItems.findIndex(
-    ({ href }) => href === pathname
-  )
+  const activeIndex = resolvedLinkItems.findIndex(({ href }) => href === path)
 
   return {
     previous: activeIndex > 0 ? resolvedLinkItems[activeIndex - 1] : undefined,

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/useResolvedSidebarUrl.ts
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/useResolvedSidebarUrl.ts
@@ -4,5 +4,5 @@ import { InternalSidebarUrlContext } from "./InternalSidebarUrlContext"
 
 export const useResolvedSidebarUrl = (href: string) => {
   const basePath = useContext(InternalSidebarUrlContext)
-  return useResolvedUrl(href, basePath)
+  return useResolvedUrl(href, basePath, { stripTrailingSlash: true })
 }

--- a/app/ui/design-system/src/lib/utils/stripTrailingSlahes.ts
+++ b/app/ui/design-system/src/lib/utils/stripTrailingSlahes.ts
@@ -1,0 +1,1 @@
+export const stripTrailingSlahes = (input: string) => input.replace(/\/+$/, "")

--- a/app/ui/design-system/src/lib/utils/useResolvedUrl.ts
+++ b/app/ui/design-system/src/lib/utils/useResolvedUrl.ts
@@ -1,16 +1,25 @@
 import { useMemo } from "react"
 import { isLinkExternal } from "./isLinkExternal"
+import { stripTrailingSlahes } from "./stripTrailingSlahes"
 
 // This is used so we have a valid base URL (which requires and origin),
 // but we strip it out anyway so the actual host name and scheme don't really
 // matter
 const PLACEHOLDER_ORIGIN = "https://placeholder"
 
+export interface UseResolvedUrlOptions {
+  stripTrailingSlash?: boolean
+}
+
 /**
  * Resolves a relative URL using the given base path. If the href provided
  * is external, the original href is returned, unmodified.
  */
-export const useResolvedUrl = (href: string, basePath: string) =>
+export const useResolvedUrl = (
+  href: string,
+  basePath: string,
+  options?: UseResolvedUrlOptions
+) =>
   useMemo(() => {
     if (isLinkExternal(href)) {
       return href
@@ -20,5 +29,10 @@ export const useResolvedUrl = (href: string, basePath: string) =>
       href,
       `${PLACEHOLDER_ORIGIN}${basePath.startsWith("/") ? "" : "/"}${basePath}`
     )
-    return url.toString().substring(url.origin.length)
-  }, [basePath, href])
+
+    const resolved = url.toString().substring(url.origin.length)
+
+    return options?.stripTrailingSlash
+      ? stripTrailingSlahes(resolved)
+      : resolved
+  }, [basePath, href, options?.stripTrailingSlash])


### PR DESCRIPTION
1. Strips any trailing slashes from docs requests and redirects if any exist for consistency and to avoid ambiguity as much as possible. 
2. Strips trailing slashes when resolving sidebar links, as well as when determining the active link within a collection of sidebar links. The should remove problems where links would not be recognized as active in some cases. 

Should reduce the number of redirects required by #489
Addresses some problems noted in #510
Fixes #523 