### PR TITLE
Render the sidebar separate from compiled content

### DIFF
--- a/app/routes/__docs/$/$.tsx
+++ b/app/routes/__docs/$/$.tsx
@@ -8,9 +8,8 @@ import { findCollection } from "../../../constants/collections.server"
 import { SIDEBAR_DROPDOWN_MENU } from "../../../constants/sidebar-dropdown-menu"
 import AppLink from "../../../ui/design-system/src/lib/Components/AppLink"
 import { ErrorPage } from "../../../ui/design-system/src/lib/Components/ErrorPage"
-import { InternaSidebarDropdownMenuGroup } from "../../../ui/design-system/src/lib/Components/InternalSidebarDropdownMenu"
 import { InternalUrlContext } from "../../../ui/design-system/src/lib/Components/InternalUrlContext"
-import { InternalPage } from "../../../ui/design-system/src/lib/Pages/InternalPage"
+import { InternalPageContent } from "../../../ui/design-system/src/lib/Pages/InternalPage/InternalPageContent"
 import logger from "../../../utils/logging.server"
 import { getSocialMetas } from "../../../utils/seo"
 
@@ -18,7 +17,6 @@ type LoaderData = {
   page: MdxPage
   data: NonNullable<ReturnType<typeof findCollection>>
   pageBasePath: string
-  sidebarDropdownMenu: InternaSidebarDropdownMenuGroup[]
 }
 
 export const loader: LoaderFunction = async ({ params, request }) => {
@@ -85,32 +83,18 @@ export const meta: MetaFunction = ({ data, location }) => {
 }
 
 export default () => {
-  const { data, page, pageBasePath, sidebarDropdownMenu } =
-    useLoaderData<LoaderData>()
+  const { data, page, pageBasePath } = useLoaderData<LoaderData>()
   const MDXContent = useMdxComponent(page)
-
-  // TODO: extract sidebarDropdownMenu and put in "constants" or somehwere
-  // alongside the doc collection definitions?
 
   return (
     <InternalUrlContext.Provider value={pageBasePath}>
-      <InternalPage
-        additionalBreadrumbs={[
-          { href: "/flow", title: "Flow" },
-          { href: "/learn", title: "Learn" },
-          { href: "/nodes", title: "Nodes" },
-          { href: "/tools", title: "Tools" },
-        ]}
-        collectionDisplayName={data.displayName}
-        collectionRootPath={data.collectionRootPath}
-        header={data.header}
+      <InternalPageContent
         sidebarItems={data.sidebar}
-        sidebarDropdownMenu={sidebarDropdownMenu}
         editPageUrl={page.origin.html_url || undefined}
         toc={page.toc}
       >
         <MDXContent />
-      </InternalPage>
+      </InternalPageContent>
     </InternalUrlContext.Provider>
   )
 }
@@ -160,4 +144,20 @@ export function CatchBoundary() {
   }
 
   throw new Error(`Unhandled error: ${caught.status}`)
+}
+
+export function ErrorBoundary({ error }: { error: Error }) {
+  console.error(error)
+  return (
+    <ErrorPage
+      className="p-10"
+      title="🙉 Something went wrong."
+      subtitle="The site is being repaired. Please check back later."
+      actions={
+        <AppLink className="underline" to="/">
+          Go home
+        </AppLink>
+      }
+    />
+  )
 }

--- a/app/ui/design-system/src/lib/Components/ErrorPage/index.tsx
+++ b/app/ui/design-system/src/lib/Components/ErrorPage/index.tsx
@@ -1,18 +1,35 @@
+import clsx from "clsx"
 import { ReactNode } from "react"
 
-export const ErrorPage = (props: {
+export const ErrorPage = ({
+  title,
+  subtitle,
+  actions,
+  className,
+}: // padding = "pty",
+{
   title: string
   subtitle: string | ReactNode
   /** e.g. a link to go back to a working state */
   actions: ReactNode
+  isComponent?: boolean
+  className?: string
 }) => {
+  const hasPadding = className?.includes("p-")
   return (
-    <div className="flex flex-1 flex-col p-12 py-80">
-      <div className="pxauto flex max-w-3xl flex-col overflow-auto ">
+    <div
+      className={clsx(
+        className,
+        "flex flex-1 flex-col",
+        hasPadding || className?.includes("px-") ? "" : "px-12",
+        hasPadding || className?.includes("py-") ? "" : "py-80"
+      )}
+    >
+      <div className="px-auto flex max-w-3xl flex-col overflow-auto ">
         <div className="grid gap-2">
-          <div className="font-extrabold">{props.title}</div>
-          <div>{props.subtitle}</div>
-          <div>{props.actions}</div>
+          <div className="font-extrabold text-red-error">{title}</div>
+          <div>{subtitle}</div>
+          <div>{actions}</div>
         </div>
       </div>
     </div>

--- a/app/ui/design-system/src/lib/Pages/InternalPage/InternalPageContainer.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/InternalPageContainer.tsx
@@ -1,0 +1,159 @@
+import { Transition } from "@headlessui/react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useLocation } from "react-router"
+import {
+  InternalLandingHeader,
+  InternalLandingHeaderProps,
+} from "../../Components/InternalLandingHeader"
+import { InternalSidebar, SidebarItem } from "../../Components/InternalSidebar"
+import { useActiveSidebarItems } from "../../Components/InternalSidebar/useActiveSidebarItems"
+import { InternaSidebarDropdownMenuGroup } from "../../Components/InternalSidebarDropdownMenu"
+import { InternalSubnav } from "../../Components/InternalSubnav"
+import { MobileMenuToggleButton } from "../../Components/NavigationBar/MobileMenuToggleButton"
+import {
+  useResizeObserver,
+  UseResizeObserverCallback,
+} from "../../utils/useResizeObserver"
+import { InternalPageEditUrlContext } from "./InternalPageEditUrlContext"
+import {
+  useInternalBreadcrumbs,
+  UseInternalBreadcrumbsOptions,
+} from "./useInternalBreadcrumbs"
+
+export type InternalPageContainerProps = React.PropsWithChildren<{
+  additionalBreadrumbs?: UseInternalBreadcrumbsOptions["additionalitems"]
+
+  /**
+   * THe name to display in the breadcrumbs for the current collection
+   */
+  collectionDisplayName: string
+
+  /**
+   * The root path for the current collection
+   */
+  collectionRootPath: string
+
+  header?: InternalLandingHeaderProps
+
+  /**
+   * The itmes to show in the dropdown menu of the sidebar.
+   */
+  sidebarDropdownMenu?: InternaSidebarDropdownMenuGroup[]
+
+  /**
+   * The configuration object that describes the page hierarchy.
+   */
+  sidebarItems?: SidebarItem[]
+}>
+
+export function InternalPageContainer({
+  additionalBreadrumbs,
+  children,
+  collectionDisplayName,
+  collectionRootPath,
+  // editPageUrl,
+  header,
+  sidebarDropdownMenu,
+  sidebarItems,
+}: InternalPageContainerProps) {
+  const [editPageUrl, setEditPageUrl] = useState<string | undefined>(undefined)
+  const [isMobileSidebarOpen, setMobileSidebarOpen] = useState(false)
+  const { active } = useActiveSidebarItems(sidebarItems || [])
+  const breadcrumbs = useInternalBreadcrumbs({
+    activeItem: active,
+    additionalitems: additionalBreadrumbs,
+    collectionDisplayName,
+    collectionRootPath,
+  })
+
+  const subnavRef = useRef<HTMLDivElement>(null)
+  const [subnavRect, setSubnavRect] = useState<DOMRect>()
+  const resizeObserverCallback = useCallback<UseResizeObserverCallback>(() => {
+    setSubnavRect(subnavRef.current?.getBoundingClientRect())
+  }, [subnavRef, setSubnavRect])
+  useResizeObserver(subnavRef, resizeObserverCallback)
+
+  const contentRef = useRef<HTMLDivElement>(null)
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    if (contentRef.current && !header) {
+      // Only scroll on pages without a header.
+      contentRef.current.scrollIntoView(true)
+    }
+  }, [pathname, header])
+
+  return (
+    <InternalPageEditUrlContext.Provider
+      value={{ value: editPageUrl, setValue: setEditPageUrl }}
+    >
+      <div className="flex flex-col pb-16" ref={contentRef}>
+        <div
+          className="sticky top-0 z-20 bg-white dark:bg-black"
+          ref={subnavRef}
+        >
+          <InternalSubnav
+            isSidebarOpen={isMobileSidebarOpen}
+            onSidebarToggle={() => setMobileSidebarOpen(!isMobileSidebarOpen)}
+            items={breadcrumbs}
+            editPageUrl={editPageUrl}
+          />
+        </div>
+        {header && <InternalLandingHeader {...header} />}
+        {sidebarItems && (
+          <Transition
+            as="div"
+            className="fixed bottom-0 left-0 right-0 z-40 bg-white dark:bg-black md:hidden"
+            style={{
+              top: subnavRect ? subnavRect.top : 0,
+            }}
+            show={isMobileSidebarOpen}
+            enter="transform transition duration-300 ease-in-out"
+            enterFrom="-translate-x-full"
+            enterTo="translate-x-0"
+            leave="transform duration-300 transition ease-in-out"
+            leaveFrom="translate-x-0"
+            leaveTo="-translate-x-full"
+          >
+            <div className="mb-2 border-b border-b-primary-gray-100 px-6 pt-1 pb-2 dark:border-b-primary-gray-300">
+              <MobileMenuToggleButton
+                className="mr-4 md:hidden"
+                height="20px"
+                isOpen
+                onOpenChanged={() => setMobileSidebarOpen(false)}
+              />
+            </div>
+            <div className="p-6">
+              <InternalSidebar
+                items={sidebarItems}
+                menu={sidebarDropdownMenu}
+              />
+            </div>
+          </Transition>
+        )}
+
+        <div className="relative flex flex-1">
+          {sidebarItems && (
+            <>
+              <aside className="hidden w-[300px] flex-none md:block">
+                <div
+                  className="sticky h-full max-h-screen overflow-auto p-8"
+                  style={{
+                    top: subnavRect?.height ?? 0,
+                    maxHeight: `calc(100vh - ${subnavRect?.bottom ?? 0}px)`,
+                  }}
+                >
+                  <InternalSidebar
+                    items={sidebarItems}
+                    menu={sidebarDropdownMenu}
+                  />
+                </div>
+              </aside>
+            </>
+          )}
+          {children}
+        </div>
+      </div>
+    </InternalPageEditUrlContext.Provider>
+  )
+}

--- a/app/ui/design-system/src/lib/Pages/InternalPage/InternalPageContent.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/InternalPageContent.tsx
@@ -1,0 +1,77 @@
+import clsx from "clsx"
+import { useCallback, useRef, useState } from "react"
+import { SidebarItem } from "../../Components/InternalSidebar"
+import { useActiveSidebarItems } from "../../Components/InternalSidebar/useActiveSidebarItems"
+import {
+  InternalToc,
+  InternalTocDisclosure,
+  InternalTocItem,
+} from "../../Components/InternalToc"
+import { LowerPageNav } from "../../Components/LowerPageNav"
+import {
+  useResizeObserver,
+  UseResizeObserverCallback,
+} from "../../utils/useResizeObserver"
+import { useProvideInternalPageEditUrl } from "./InternalPageEditUrlContext"
+
+export type InternalPageContentProps = React.PropsWithChildren<{
+  editPageUrl?: string
+
+  /**
+   * The configuration object that describes the page hierarchy.
+   */
+  sidebarItems?: SidebarItem[]
+
+  toc?: InternalTocItem[]
+}>
+
+export function InternalPageContent({
+  children,
+  editPageUrl,
+  sidebarItems,
+  toc,
+}: InternalPageContentProps) {
+  useProvideInternalPageEditUrl(editPageUrl)
+  const { previous, next } = useActiveSidebarItems(sidebarItems || [])
+  const subnavRef = useRef<HTMLDivElement>(null)
+  const [subnavRect, setSubnavRect] = useState<DOMRect>()
+  const resizeObserverCallback = useCallback<UseResizeObserverCallback>(() => {
+    setSubnavRect(subnavRef.current?.getBoundingClientRect())
+  }, [subnavRef, setSubnavRect])
+  useResizeObserver(subnavRef, resizeObserverCallback)
+
+  return (
+    <main
+      className={clsx("flex max-w-full shrink-0 grow flex-row-reverse", {
+        "md:max-w-[calc(100%_-_300px)]": sidebarItems,
+      })}
+    >
+      {toc && (
+        <div className="hidden flex-none md:flex md:w-1/4">
+          <div
+            className="sticky h-full max-h-screen overflow-auto p-8"
+            style={{
+              top: subnavRect?.height ?? 0,
+              maxHeight: `calc(100vh - ${subnavRect?.bottom ?? 0}px)`,
+            }}
+          >
+            <InternalToc headings={toc} />
+          </div>
+        </div>
+      )}
+      <div
+        className={clsx("w-full flex-none p-8 pl-16 pb-80", {
+          "md:w-3/4": !!toc,
+        })}
+      >
+        {toc && (
+          <div className="md:hidden">
+            <InternalTocDisclosure headings={toc} />
+          </div>
+        )}
+        <div>{children}</div>
+        <LowerPageNav prev={previous} next={next} />
+      </div>
+    </main>
+  )
+}

--- a/app/ui/design-system/src/lib/Pages/InternalPage/InternalPageEditUrlContext.ts
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/InternalPageEditUrlContext.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext, useEffect } from "react"
+
+export const InternalPageEditUrlContext = createContext<{
+  value: undefined | string
+  setValue: (newValue: undefined | string) => void
+}>({
+  value: undefined,
+  setValue: () => {},
+})
+
+/**
+ * Sets the "edit page" URL for the current content.  Allows a child component
+ * to tell a parent component what the URL should be.
+ */
+export const useProvideInternalPageEditUrl = (url: string | undefined) => {
+  const { setValue } = useContext(InternalPageEditUrlContext)
+
+  useEffect(() => {
+    setValue(url)
+
+    return () => {
+      setValue(undefined)
+    }
+  }, [setValue, url])
+}


### PR DESCRIPTION
This allows the sidebar and other content to render even if the MDX compilation fails. 

<img width="949" alt="Screen Shot 2022-08-10 at 1 54 14 PM" src="https://user-images.githubusercontent.com/393220/183982913-4abf0c15-5564-44d5-a653-a3322bb8e071.png">

It splits the `InternalPage` component into `InternalPageContainer` and `InternalPageContent`. 

I had to get a little creative with how the `editPageUrl` is provided since that isn't available until after we download and identify the file we are going to render, but we need to provide it to the outer layout.  So that is handled by `InternalPageEditUrlContext`.
