### PR TITLE
Reset/restore scroll on navigation change

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -42,6 +42,7 @@ import { SearchProps } from "./ui/design-system/src/lib/Components/Search"
 import { getMetaTitle } from "./utils/seo"
 
 import redirects from "./redirects"
+import { useElementScrollRestoration } from "./utils/useElementScrollRestoration"
 
 export { getMetaTitle } from "./utils/seo"
 
@@ -134,6 +135,9 @@ function TopLoader() {
 }
 
 function App() {
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  useElementScrollRestoration(scrollContainerRef)
+
   const data = useLoaderData<LoaderData>()
 
   const [theme, setTheme] = useTheme()
@@ -195,7 +199,7 @@ function App() {
           onDarkModeToggle={toggleTheme}
           algolia={data.algolia}
         />
-        <div className="flex-auto overflow-auto">
+        <div className="flex-auto overflow-auto" ref={scrollContainerRef}>
           <TopLoader />
           <Outlet />
           <Footer />

--- a/app/utils/useElementScrollRestoration.ts
+++ b/app/utils/useElementScrollRestoration.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react"
+import { useLocation, useTransition } from "@remix-run/react"
+import { useIsomorphicLayoutEffect } from "../ui/design-system/src/lib/utils/useIsomorphicLayoutEffect"
+
+/**
+ * Handles scroll restoration and reseting for a scrolling container element
+ *
+ * Code taken from: {@link https://github.com/remix-run/remix/issues/186#issuecomment-895583783}
+ *
+ * @param ref The scrolling element
+ * @param enabled True if scroll restoration is enabled, otherwise false.
+ */
+export function useElementScrollRestoration(
+  ref: React.MutableRefObject<HTMLElement | null>,
+  enabled: boolean = true
+) {
+  const positions = useRef<Map<string, number>>(new Map()).current
+  const location = useLocation()
+  const transition = useTransition()
+
+  useEffect(() => {
+    if (!ref.current) return
+    if (transition.state === "loading") {
+      positions.set(location.key, ref.current.scrollTop)
+    }
+  }, [transition.state, location.key, ref, positions])
+
+  useIsomorphicLayoutEffect(() => {
+    if (!enabled) return
+    if (transition.state !== "idle") return
+    if (!ref.current) return
+    const y = positions.get(location.key)
+    ref.current.scrollTo(0, y ?? 0)
+  }, [transition.state, location.key, positions, ref])
+}


### PR DESCRIPTION
Remix does not have support for reseting/restoring scroll position anywhere except in the main window. We use a flexbox layout with an inner scrolling container, so that doesn't work for us. This change applies scroll reset/restore to our main scroll container.