### PR TITLE
Add min height to nav bar tab pane

### DIFF
--- a/app/ui/design-system/src/lib/Components/NavigationBar/MenuContent.tsx
+++ b/app/ui/design-system/src/lib/Components/NavigationBar/MenuContent.tsx
@@ -24,7 +24,7 @@ export function MenuContent({
   const isSingleSection = sections.length === 1
   const hasCards = cards.length > 0
   const contentClasses = clsx(
-    "flex h-full flex-col gap-6 bg-white p-4 dark:bg-primary-gray-dark md:flex-row",
+    "flex h-full flex-col gap-6 bg-white p-4 dark:bg-primary-gray-dark md:flex-row min-h-[460px]",
     className
   )
   return (


### PR DESCRIPTION
Addresses #551 

Bottom links on the nav bar should all be at a consistent level. Ensure the `Setup` tab's bottom links (the purple ones) are aligned with the other tabs.