### PR TITLE
Use explicit transparent gradient color

### DIFF
--- a/app/ui/design-system/src/lib/Components/InternalSubnav/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSubnav/index.tsx
@@ -26,7 +26,7 @@ export function InternalSubnav({
   return (
     <div
       className={clsx(
-        "flex flex-wrap items-center justify-between border-b border-b-primary-gray-100 bg-white bg-gradient-to-b from-primary-gray-50 via-transparent to-transparent px-6 dark:border-b-primary-gray-300 dark:bg-black dark:from-transparent",
+        "via-[rgba(255, 0, 0, 0)] to-[rgba(255, 0, 0, 0)] flex flex-wrap items-center justify-between border-b border-b-primary-gray-100 bg-white bg-gradient-to-b from-primary-gray-50 px-6 dark:border-b-primary-gray-300 dark:bg-black dark:from-transparent",
         className
       )}
     >


### PR DESCRIPTION
Older versions of safari do not handle transparent gradients correctly, as seen here:

<img width="1508" alt="Screen Shot 2022-08-12 at 9 38 36 AM" src="https://user-images.githubusercontent.com/393220/184408921-e7207e60-ff12-4d1f-88bb-0dae6ff55de8.png">


See: https://css-tricks.com/thing-know-gradients-transparent-black/

