### PR TITLE
Fix videoId extraction for video cards

### DIFF
--- a/app/ui/design-system/src/lib/Components/VideoCard/LargeVideoCard.tsx
+++ b/app/ui/design-system/src/lib/Components/VideoCard/LargeVideoCard.tsx
@@ -3,12 +3,15 @@ import { useState } from "react"
 
 import PlayCircle from "../../../../images/action/play-circle.svg"
 import { ReactComponent as Time } from "../../../../images/content/date"
+import { useExtractYoutubeVideoId } from "./useExtractYoutubeVideoId"
+import { VideoCardError, VideoCardErrorProps } from "./VideoCardError"
 
 export interface LargeVideoCardProps {
   link: string // NOTE: link should be in the format that youtubes site uses ie: https://www.youtube.com/watch?v=...
   title: string
   length: number // seconds
   className?: string
+  errorBehavior?: VideoCardErrorProps["behavior"]
 }
 
 export function LargeVideoCard({
@@ -16,18 +19,24 @@ export function LargeVideoCard({
   title,
   length,
   className,
+  errorBehavior = "render-comment",
 }: LargeVideoCardProps) {
+  const extractResult = useExtractYoutubeVideoId(link)
   const [showOverlay, setShowOverlay] = useState(true)
 
   const minutes = String(Math.floor(length / 60)).padStart(2, "0")
   const seconds = length % 60
 
-  const url = new URL(link)
-  const videoId = url.searchParams.get("v")
-
-  if (url.hostname !== "www.youtube.com") {
-    throw new Error("VideoCard only accepts youtube embeds")
+  if ("error" in extractResult) {
+    return (
+      <VideoCardError
+        behavior={errorBehavior}
+        error={`${extractResult.error}. LargeVideoCard expects a YouTube embed URL containing a video ID`}
+      />
+    )
   }
+
+  const { videoId } = extractResult
 
   return (
     <div

--- a/app/ui/design-system/src/lib/Components/VideoCard/SmallVideoCard.tsx
+++ b/app/ui/design-system/src/lib/Components/VideoCard/SmallVideoCard.tsx
@@ -4,6 +4,8 @@ import { ReactComponent as ExternalLinkIcon } from "../../../../images/content/e
 import AppLink from "../AppLink"
 import Tag from "../Tag"
 import { LargeVideoCardProps } from "./LargeVideoCard"
+import { useExtractYoutubeVideoId } from "./useExtractYoutubeVideoId"
+import { VideoCardError } from "./VideoCardError"
 
 export interface SmallVideoCardProps extends LargeVideoCardProps {
   tags: string[]
@@ -14,14 +16,19 @@ export function SmallVideoCard({
   length,
   tags,
   link,
+  errorBehavior = "render-comment",
 }: SmallVideoCardProps) {
+  const extractResult = useExtractYoutubeVideoId(link)
   const minutes = String(Math.floor(length / 60)).padStart(2, "0")
   const seconds = length % 60
 
-  const url = new URL(link)
-
-  if (url.hostname !== "www.youtube.com") {
-    throw new Error("VideoCard only accepts youtube embeds")
+  if ("error" in extractResult) {
+    return (
+      <VideoCardError
+        behavior={errorBehavior}
+        error={`${extractResult.error}. SmallVideoCard expects a YouTube embed URL containing a video ID`}
+      />
+    )
   }
 
   return (

--- a/app/ui/design-system/src/lib/Components/VideoCard/VideoCardError.tsx
+++ b/app/ui/design-system/src/lib/Components/VideoCard/VideoCardError.tsx
@@ -1,0 +1,29 @@
+export interface VideoCardErrorProps {
+  behavior: "throw" | "render-comment" | "render-null"
+  error: string
+}
+
+/**
+ *
+ * Rendered when there is an error extracting the video ID from a video `link`.
+ * @returns
+ */
+export function VideoCardError({ behavior, error }: VideoCardErrorProps) {
+  switch (behavior) {
+    case "throw": {
+      throw error
+    }
+    case "render-comment": {
+      return (
+        <span
+          dangerouslySetInnerHTML={{
+            __html: `<!-- ${error.replace(/--/, " - ")} -->`,
+          }}
+        />
+      )
+    }
+    case "render-null": {
+      return null
+    }
+  }
+}

--- a/app/ui/design-system/src/lib/Components/VideoCard/useExtractYoutubeVideoId.ts
+++ b/app/ui/design-system/src/lib/Components/VideoCard/useExtractYoutubeVideoId.ts
@@ -5,7 +5,9 @@ import React from "react"
  * https://gist.github.com/rodrigoborgesdeoliveira/987683cfbfcc8d800192da1e73adc486?permalink_comment_id=3262368#gistcomment-3262368
  * it seems pretty exhaustive and works for our current use-cases.
  */
+//
 const YOUTUBE_URL_REGEX =
+  // eslint-disable-next-line
   /(?:http:|https:)*?\/\/(?:www\.|)(?:youtube\.com|m\.youtube\.com|youtu\.|youtube-nocookie\.com).*(?:v=|v%3D|v\/|(?:a|p)\/(?:a|u)\/\d.*\/|watch\?|vi(?:=|\/)|\/embed\/|oembed\?|be\/|e\/)([^&?%#\/\n]*)/im
 
 export type ExtractYoutubeVideoIdResult =

--- a/app/ui/design-system/src/lib/Components/VideoCard/useExtractYoutubeVideoId.ts
+++ b/app/ui/design-system/src/lib/Components/VideoCard/useExtractYoutubeVideoId.ts
@@ -1,0 +1,40 @@
+import React from "react"
+
+/**
+ * There are many formats for a Youtube embed URL. I took this regex from:
+ * https://gist.github.com/rodrigoborgesdeoliveira/987683cfbfcc8d800192da1e73adc486?permalink_comment_id=3262368#gistcomment-3262368
+ * it seems pretty exhaustive and works for our current use-cases.
+ */
+const YOUTUBE_URL_REGEX =
+  /(?:http:|https:)*?\/\/(?:www\.|)(?:youtube\.com|m\.youtube\.com|youtu\.|youtube-nocookie\.com).*(?:v=|v%3D|v\/|(?:a|p)\/(?:a|u)\/\d.*\/|watch\?|vi(?:=|\/)|\/embed\/|oembed\?|be\/|e\/)([^&?%#\/\n]*)/im
+
+export type ExtractYoutubeVideoIdResult =
+  | {
+      error: string
+    }
+  | {
+      videoId: string
+    }
+
+export const useExtractYoutubeVideoId = (
+  src: string
+): ExtractYoutubeVideoIdResult =>
+  React.useMemo(() => {
+    const result = src.match(YOUTUBE_URL_REGEX)
+
+    if (!result) {
+      return {
+        error: "Unrecognized URL",
+      }
+    }
+
+    if (!result[1]) {
+      return {
+        error: "Video ID not found",
+      }
+    }
+
+    return {
+      videoId: result[1],
+    }
+  }, [src])


### PR DESCRIPTION
- Adds a more flexible regex for extracting the video ID from a YouTube embed URL.
- When an error occurs extracting the videoId, renders and HTML comment (`<-- ... -->`) with the error message so it's easier to understand why the error failed (this behavior can be override with the `errorBehavior` prop)

Fixes #565 