### PR TITLE
Metadata fixes

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -66,7 +66,7 @@ export const links: LinksFunction = () => {
 export const meta: MetaFunction = ({ data, location }) => ({
   ...getSocialMetas({
     title: getMetaTitle(),
-    url: location.toString(),
+    url: data.url,
   }),
   charset: "utf-8",
   viewport: "width=device-width,initial-scale=1",
@@ -77,6 +77,7 @@ export type LoaderData = {
   gaTrackingId: string | undefined
   ENV: PUBLIC_ENV
   algolia?: SearchProps
+  url: string
 }
 
 export const loader: LoaderFunction = async ({ request }) => {
@@ -111,6 +112,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     ),
     ENV: getPublicEnv(),
     algolia,
+    url: request.url,
   })
 }
 

--- a/app/routes/__docs/$/$.tsx
+++ b/app/routes/__docs/$/$.tsx
@@ -17,6 +17,7 @@ type LoaderData = {
   page: MdxPage
   data: NonNullable<ReturnType<typeof findCollection>>
   pageBasePath: string
+  url: string
 }
 
 export const loader: LoaderFunction = async ({ params, request }) => {
@@ -57,6 +58,7 @@ export const loader: LoaderFunction = async ({ params, request }) => {
       page,
       pageBasePath,
       sidebarDropdownMenu: SIDEBAR_DROPDOWN_MENU,
+      url: request.url,
     })
   } catch (e) {
     if (e instanceof NotFoundError) {
@@ -79,14 +81,14 @@ export const meta: MetaFunction = ({ data, location }) => {
     return getSocialMetas({
       title,
       description: description || "Flow Developer Documentation",
-      url: location.toString(),
+      url: data.url,
       image: `https://flow-og-image.vercel.app/**${title}**%20${description}.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fstorage.googleapis.com%2Fflow-resources%2Fdocumentation-assets%2Fflow-docs.png&widths=auto&heights=350"`,
     })
   }
 
   return getSocialMetas({
     title: "Flow Developer Portal",
-    url: location.toString(),
+    url: data.url,
   })
 }
 

--- a/app/routes/__docs/$/$.tsx
+++ b/app/routes/__docs/$/$.tsx
@@ -72,7 +72,8 @@ export const loader: LoaderFunction = async ({ params, request }) => {
 export const meta: MetaFunction = ({ data, location }) => {
   const typedData = data as LoaderData
   if (typedData && typedData.page) {
-    const title = typedData.page.frontmatter?.title
+    const title =
+      typedData.page.frontmatter?.title || "Flow Developer Documentation"
     const description = typedData.page.frontmatter?.description || ""
 
     return getSocialMetas({

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -19,7 +19,7 @@ export function getSocialMetas({
     keywords,
     image,
     "og:url": url,
-    "og:title": title,
+    "og:title": title || "Flow Developer Documentation",
     "og:description": description,
     "og:image": image,
     "twitter:card": image ? "summary_large_image" : "summary",


### PR DESCRIPTION
1. Fixes #577 by providing a default title when generating the `og:image` url. 
2. Fixes all `og:url` tags, which were previously always set to the literal string "[object Object]". 