### PR TITLE
Fix table of contents links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ You'll need to acquire the project's `.env` file before continuing.
 2. `yarn build`
 3. `docker compose up`
 
+   -or, to also bring up Storybook-
+
+   `docker compose --profile storybook up`
+
 Main application: http://localhost:3000/
-Storybook: http://localhost:6006/
+Storybook: http://localhost:6006/ (if started using `--profile storybook`)
 
 #### Useful docker commands and tips
 

--- a/app/utils/useElementScrollRestoration.ts
+++ b/app/utils/useElementScrollRestoration.ts
@@ -16,7 +16,12 @@ export function useElementScrollRestoration(
 ) {
   const positions = useRef<Map<string, number>>(new Map()).current
   const location = useLocation()
+  const previousLocation = useRef<ReturnType<typeof useLocation>>()
   const transition = useTransition()
+
+  useEffect(() => {
+    previousLocation.current = location
+  }, [location])
 
   useEffect(() => {
     if (!ref.current) return
@@ -29,6 +34,15 @@ export function useElementScrollRestoration(
     if (!enabled) return
     if (transition.state !== "idle") return
     if (!ref.current) return
+
+    // Don't reset/restore scroll if the pathname and search match (likely
+    // meaning just the hash was changed).
+    if (
+      previousLocation.current?.pathname === location.pathname &&
+      previousLocation.current.search === location.search
+    )
+      return
+
     const y = positions.get(location.key)
     ref.current.scrollTo(0, y ?? 0)
   }, [transition.state, location.key, positions, ref])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.9"
 
 networks:
   next-docs-net:
@@ -71,8 +71,9 @@ services:
     depends_on:
       - app-css
       - app-svg
-  # storybook:
-  #   <<: *app-defaults
-  #   command: ["yarn", "run", "start-storybook", "-p", "6006", "--quiet", "--no-open", "--disable-telemetry"]
-  #   ports:
-  #     - "6006:6006"
+  storybook:
+    <<: *app-defaults
+    profiles: ["storybook"]
+    command: ["yarn", "run", "start-storybook", "-p", "6006", "--quiet", "--no-open", "--disable-telemetry"]
+    ports:
+      - "6006:6006"


### PR DESCRIPTION
The (right hand side menu) table of contents links weren't working when the scroll restoration was fixed, because whenever a link was clicked, even if it was just a hash change, we reset the scroll position. So this fixes that.

Also gives the `storybook` service a profile name in the `docker-compose.yml` file. This way it doesn't start unless you explicitly tell it to with `docker compose --profile storybook up`. README was also updated with relevant info. 

Fixes #588 
Fixes #581 