### PR TITLE
Styling updates to internal pages

### DIFF
--- a/app/cms/utils/mdx.tsx
+++ b/app/cms/utils/mdx.tsx
@@ -292,7 +292,7 @@ function getMdxComponent(page: MdxPage, theme: Theme | null) {
           </div>
         )}
 
-        <p>{frontmatter.description}</p>
+        {!!frontmatter.description && <p>{frontmatter.description}</p>}
 
         <Component
           /* @ts-expect-error: Does not like the link tage type definition above */

--- a/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
+++ b/app/ui/design-system/src/lib/Components/InternalSidebar/index.tsx
@@ -40,9 +40,9 @@ const InternalSidebarLinkItem = ({ item }: { item: SidebarLinkItem }) => {
       prefetch="intent"
       className={({ isActive }) =>
         clsx(
-          "mb-1 block rounded-md px-2 py-1.5 text-sm text-primary-gray-400 hover:opacity-75 dark:text-gray-200",
+          "mb-1 block rounded-md py-1.5 text-primary-gray-400 hover:opacity-75 dark:text-gray-200",
           {
-            "bg-gray-200 bg-opacity-50 text-primary-blue dark:bg-gray-700 dark:text-gray-300":
+            "font-semibold text-primary-blue dark:text-blue-hover-dark":
               isActive,
           }
         )
@@ -63,7 +63,7 @@ const InternalSidebarItem = ({ item }: { item: SidebarItem }) => (
       </div>
     )}
     {item.items?.map((subItem, index) => (
-      <div className="px-4" key={index}>
+      <div key={index}>
         <InternalSidebarItem item={subItem} />
       </div>
     ))}

--- a/app/ui/design-system/src/lib/Pages/InternalPage/InternalPageContainer.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/InternalPageContainer.tsx
@@ -135,7 +135,7 @@ export function InternalPageContainer({
         <div className="relative flex flex-1">
           {sidebarItems && (
             <>
-              <aside className="hidden w-[300px] flex-none md:block">
+              <aside className="hidden w-[300px] flex-none bg-primary-gray-50 dark:bg-primary-gray-dark md:block">
                 <div
                   className="sticky h-full max-h-screen overflow-auto p-8"
                   style={{

--- a/app/ui/design-system/src/lib/Pages/InternalPage/InternalPageContent.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/InternalPageContent.tsx
@@ -42,9 +42,12 @@ export function InternalPageContent({
 
   return (
     <main
-      className={clsx("flex max-w-full shrink-0 grow flex-row-reverse", {
-        "md:max-w-[calc(100%_-_300px)]": sidebarItems,
-      })}
+      className={clsx(
+        "flex max-w-full shrink-0 grow flex-row-reverse justify-center",
+        {
+          "md:max-w-[calc(100%_-_300px)]": sidebarItems,
+        }
+      )}
     >
       {toc && (
         <div className="hidden flex-none md:flex md:w-1/4">
@@ -61,7 +64,7 @@ export function InternalPageContent({
       )}
       <div
         className={clsx("w-full flex-none p-8 pb-80", {
-          "md:w-3/4": !!toc,
+          "md:w-3/4 md:max-w-[730px]": !!toc,
         })}
       >
         {toc && (

--- a/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
+++ b/app/ui/design-system/src/lib/Pages/InternalPage/index.tsx
@@ -136,7 +136,7 @@ export function InternalPage({
       <div className="relative flex flex-1">
         {sidebarItems && (
           <>
-            <aside className="hidden w-[300px] flex-none md:block">
+            <aside className="dark:primary-gray-dark hidden w-[300px] flex-none bg-primary-gray-50 md:block">
               <div
                 className="sticky h-full max-h-screen overflow-auto p-8"
                 style={{
@@ -172,7 +172,7 @@ export function InternalPage({
           )}
           <div
             className={clsx("w-full flex-none p-8 pl-16 pb-80", {
-              "md:w-3/4": !!toc,
+              "md:max-w-[730px]": !!toc,
             })}
           >
             {toc && (


### PR DESCRIPTION
Closes #571 

Now the internal pages have a set content width and the left sidebar looks more like the Figma designs.

I couldn't reproduce the scrolling issue so that's not addressed in these changes. In addition, the order of the content header and attribution can only be fixed by adding missing frontmatter content to each of the docs. (@10thfloor let me know otherwise)