### PR TITLE
Invalidate documents in github webhook processing action

### DIFF
--- a/app/cms/cache-keys.server.ts
+++ b/app/cms/cache-keys.server.ts
@@ -1,0 +1,10 @@
+import type { DocCollectionSource } from "~/constants/doc-collections.server"
+
+export const getCompiledKey = (source: DocCollectionSource, path: string) =>
+  `${source.owner}:${source.name}:${source.branch}:${source.rootPath}:${path}:compiled`
+
+export const getDownloadKey = (
+  source: DocCollectionSource,
+  fileOrDirPath: string
+) =>
+  `${source.owner}:${source.name}:${source.branch}:${source.rootPath}:${fileOrDirPath}:downloaded`

--- a/app/cms/cache-keys.server.ts
+++ b/app/cms/cache-keys.server.ts
@@ -1,9 +1,12 @@
 import type { DocCollectionSource } from "~/constants/doc-collections.server"
 
-export const getCompiledKey = (source: DocCollectionSource, path: string) =>
+export const documentCompiledKey = (
+  source: DocCollectionSource,
+  path: string
+) =>
   `${source.owner}:${source.name}:${source.branch}:${source.rootPath}:${path}:compiled`
 
-export const getDownloadKey = (
+export const documentDownloadKey = (
   source: DocCollectionSource,
   fileOrDirPath: string
 ) =>

--- a/app/cms/github-webhook.server.test.ts
+++ b/app/cms/github-webhook.server.test.ts
@@ -17,7 +17,7 @@ let exampleEvent: any = {
   ],
 }
 
-test("it clears the expected cache keys when files are modified", () => {
+test("it clears manifest cache keys when flow-docs.json is modified", () => {
   const event: any = {
     ...exampleEvent,
     commits: [
@@ -33,6 +33,71 @@ test("it clears the expected cache keys when files are modified", () => {
 
   expect(result.cacheKeysToInvalidate).toEqual(
     new Set([`manifest:onflow:mock-developer-doc:json-manifest-valid`])
+  )
+})
+
+test("it returns document cache keys when document are modified", () => {
+  const event: any = {
+    ...exampleEvent,
+    commits: [
+      {
+        added: [],
+        removed: [],
+        modified: ["docs/faq.md", "docs/foobar.mdx", "src/something.ts"],
+      },
+    ],
+  }
+
+  const result = pushEventCacheKeysToInvalidate(event)
+
+  const keyPrefix = [
+    `onflow`,
+    `mock-developer-doc`,
+    `json-manifest-valid`,
+    `docs/`,
+  ].join(":")
+
+  expect(result.cacheKeysToInvalidate).toEqual(
+    new Set([
+      `${keyPrefix}:faq:compiled`,
+      `${keyPrefix}:faq:downloaded`,
+      `${keyPrefix}:foobar:compiled`,
+      `${keyPrefix}:foobar:downloaded`,
+    ])
+  )
+})
+
+test("it returns special paths for index documents", () => {
+  const event: any = {
+    ...exampleEvent,
+    commits: [
+      {
+        added: [],
+        removed: [],
+        modified: ["docs/index.md", "docs/foo/index.mdx"],
+      },
+    ],
+  }
+
+  const result = pushEventCacheKeysToInvalidate(event)
+  const keyPrefix = [
+    `onflow`,
+    `mock-developer-doc`,
+    `json-manifest-valid`,
+    `docs/`,
+  ].join(":")
+
+  expect(result.cacheKeysToInvalidate).toEqual(
+    new Set([
+      `${keyPrefix}:index:compiled`,
+      `${keyPrefix}:index:downloaded`,
+      `${keyPrefix}::compiled`,
+      `${keyPrefix}::downloaded`,
+      `${keyPrefix}:foo/index:compiled`,
+      `${keyPrefix}:foo/index:downloaded`,
+      `${keyPrefix}:foo:compiled`,
+      `${keyPrefix}:foo:downloaded`,
+    ])
   )
 })
 

--- a/app/cms/github-webhook.server.ts
+++ b/app/cms/github-webhook.server.ts
@@ -6,7 +6,7 @@ import {
   manifestCacheKey,
 } from "~/constants/doc-collection-manifest"
 import { docCollections } from "~/constants/doc-collections.server"
-import { getCompiledKey, getDownloadKey } from "./cache-keys.server"
+import { documentCompiledKey, documentDownloadKey } from "./cache-keys.server"
 
 type ProcessResult = {
   docCollectionStatus: "match" | "not-found"
@@ -64,16 +64,16 @@ export function pushEventCacheKeysToInvalidate(
     let urlPath = path.slice(docCollection.source.rootPath.length)
     urlPath = urlPath.replace(/\.[^/.]+$/, "")
 
-    let compiledKey = getCompiledKey(docCollection.source, urlPath)
-    let downloadKey = getDownloadKey(docCollection.source, urlPath)
+    let compiledKey = documentCompiledKey(docCollection.source, urlPath)
+    let downloadKey = documentDownloadKey(docCollection.source, urlPath)
 
     keysToInvalidate.add(compiledKey)
     keysToInvalidate.add(downloadKey)
 
     if (isIndex) {
       let rootPath = urlPath.replace(/\/?index/, "")
-      let rootCompiledKey = getCompiledKey(docCollection.source, rootPath)
-      let rootDownloadKey = getDownloadKey(docCollection.source, rootPath)
+      let rootCompiledKey = documentCompiledKey(docCollection.source, rootPath)
+      let rootDownloadKey = documentDownloadKey(docCollection.source, rootPath)
 
       keysToInvalidate.add(rootCompiledKey)
       keysToInvalidate.add(rootDownloadKey)

--- a/app/cms/github-webhook.server.ts
+++ b/app/cms/github-webhook.server.ts
@@ -1,11 +1,11 @@
 import { PushEvent } from "@octokit/webhooks-types"
+import { posix } from "node:path"
 import invariant from "tiny-invariant"
-import { docCollections } from "~/constants/doc-collections.server"
-import { posix, parse } from "node:path"
 import {
   JSON_MANIFEST_FILENAME,
   manifestCacheKey,
 } from "~/constants/doc-collection-manifest"
+import { docCollections } from "~/constants/doc-collections.server"
 import { getCompiledKey, getDownloadKey } from "./cache-keys.server"
 
 type ProcessResult = {

--- a/app/cms/github-webhook.server.ts
+++ b/app/cms/github-webhook.server.ts
@@ -53,28 +53,30 @@ export function pushEventCacheKeysToInvalidate(
     keysToInvalidate.add(manifestCacheKey(docCollection.source))
   }
 
-  for (let path of allChangedFiles) {
+  let documentPaths = allChangedFiles.filter((path) => {
     let isDocumentPath = path.startsWith(docCollection.source.rootPath)
     let isDocument = path.endsWith(".md") || path.endsWith(".mdx")
-    if (isDocumentPath && isDocument) {
-      let isIndex = path.endsWith("index.md") || path.endsWith("index.mdx")
-      let urlPath = path.slice(docCollection.source.rootPath.length)
-      urlPath = urlPath.replace(/\.[^/.]+$/, "")
+    return isDocumentPath && isDocument
+  })
 
-      let compiledKey = getCompiledKey(docCollection.source, urlPath)
-      let downloadKey = getDownloadKey(docCollection.source, urlPath)
+  for (let path of documentPaths) {
+    let isIndex = path.endsWith("index.md") || path.endsWith("index.mdx")
+    let urlPath = path.slice(docCollection.source.rootPath.length)
+    urlPath = urlPath.replace(/\.[^/.]+$/, "")
 
-      keysToInvalidate.add(compiledKey)
-      keysToInvalidate.add(downloadKey)
+    let compiledKey = getCompiledKey(docCollection.source, urlPath)
+    let downloadKey = getDownloadKey(docCollection.source, urlPath)
 
-      if (isIndex) {
-        let rootPath = urlPath.replace(/\/?index/, "")
-        let rootCompiledKey = getCompiledKey(docCollection.source, rootPath)
-        let rootDownloadKey = getDownloadKey(docCollection.source, rootPath)
+    keysToInvalidate.add(compiledKey)
+    keysToInvalidate.add(downloadKey)
 
-        keysToInvalidate.add(rootCompiledKey)
-        keysToInvalidate.add(rootDownloadKey)
-      }
+    if (isIndex) {
+      let rootPath = urlPath.replace(/\/?index/, "")
+      let rootCompiledKey = getCompiledKey(docCollection.source, rootPath)
+      let rootDownloadKey = getDownloadKey(docCollection.source, rootPath)
+
+      keysToInvalidate.add(rootCompiledKey)
+      keysToInvalidate.add(rootDownloadKey)
     }
   }
 

--- a/app/cms/utils/mdx.tsx
+++ b/app/cms/utils/mdx.tsx
@@ -23,6 +23,7 @@ import {
 } from "~/ui/design-system"
 import { DocCollectionSource } from "../../constants/doc-collections.server"
 import { InternalImg } from "../../ui/design-system/src/lib/Components/InternalImg/InternalImg"
+import { getCompiledKey, getDownloadKey } from "../cache-keys.server"
 import { returnRedirectForRoute } from "./return-redirect-for-route"
 import { Theme, useTheme } from "./theme.provider"
 
@@ -35,9 +36,6 @@ type CachifiedOptions = {
 }
 
 const defaultMaxAge = 1000 * 60 * 60 * 24 * 30
-
-const getCompiledKey = (source: DocCollectionSource, path: string) =>
-  `${source.owner}:${source.name}:${source.branch}:${source.rootPath}:${path}:compiled`
 
 const checkCompiledValue = (value: unknown) =>
   typeof value === "object" &&
@@ -98,9 +96,6 @@ export async function getMdxPage(
 
   return page
 }
-
-const getDownloadKey = (source: DocCollectionSource, fileOrDirPath: string) =>
-  `${source.owner}:${source.name}:${source.branch}:${source.rootPath}:${fileOrDirPath}:downloaded`
 
 async function downloadMarkdownCached(
   source: DocCollectionSource,

--- a/app/cms/utils/mdx.tsx
+++ b/app/cms/utils/mdx.tsx
@@ -23,7 +23,7 @@ import {
 } from "~/ui/design-system"
 import { DocCollectionSource } from "../../constants/doc-collections.server"
 import { InternalImg } from "../../ui/design-system/src/lib/Components/InternalImg/InternalImg"
-import { getCompiledKey, getDownloadKey } from "../cache-keys.server"
+import { documentCompiledKey, documentDownloadKey } from "../cache-keys.server"
 import { returnRedirectForRoute } from "./return-redirect-for-route"
 import { Theme, useTheme } from "./theme.provider"
 
@@ -53,7 +53,7 @@ export async function getMdxPage(
   },
   options: CachifiedOptions
 ): Promise<MdxPage | null> {
-  const key = getCompiledKey(source, path)
+  const key = documentCompiledKey(source, path)
   const page = await cachified({
     cache: redisCache,
     maxAge: defaultMaxAge,
@@ -102,7 +102,7 @@ async function downloadMarkdownCached(
   fileOrDirPath: string,
   options: CachifiedOptions
 ) {
-  const key = getDownloadKey(source, fileOrDirPath)
+  const key = documentDownloadKey(source, fileOrDirPath)
   const downloaded = await cachified({
     cache: redisCache,
     maxAge: defaultMaxAge,
@@ -153,7 +153,7 @@ async function compileMdxCached({
   isTrusted: boolean
   options: CachifiedOptions
 }) {
-  const key = getCompiledKey(source, fileOrDirPath)
+  const key = documentCompiledKey(source, fileOrDirPath)
   const page = await cachified({
     cache: redisCache,
     maxAge: defaultMaxAge,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -120,10 +120,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 
   return json<LoaderData>({
     theme: themeSession.getTheme(),
-    gaTrackingId: getRequiredServerEnvVar(
-      "GA_TRACKING_ID",
-      "GA_TRACKING_ID-dev-value"
-    ),
+    gaTrackingId: process.env.GA_TRACKING_ID,
     ENV: getPublicEnv(),
     algolia,
     url: request.url,
@@ -168,7 +165,7 @@ function App() {
 
   const location = useLocation()
   useEffect(() => {
-    if (data.gaTrackingId?.length) {
+    if (data.gaTrackingId != null) {
       gtag.pageview(location.pathname, data.gaTrackingId)
     }
   }, [location, data.gaTrackingId])
@@ -184,7 +181,7 @@ function App() {
         <ThemeHead ssrTheme={Boolean(data.theme)} />
       </head>
       <body className="root">
-        {!data.gaTrackingId ? null : (
+        {data.gaTrackingId != null ? (
           <>
             <script
               async
@@ -193,7 +190,7 @@ function App() {
             <script
               async
               id="gtag-init"
-              src={`gtag-init?gaTrackingId=${data.gaTrackingId}`}
+              src={`/gtag-init?gaTrackingId=${data.gaTrackingId}`}
             />
             <script
               dangerouslySetInnerHTML={{
@@ -201,7 +198,7 @@ function App() {
               }}
             />
           </>
-        )}
+        ) : null}
 
         <ThemeBody ssrTheme={Boolean(data.theme)} />
         <NavigationBar


### PR DESCRIPTION
clears more cache keys when processing github webhook requests. this will allow us to deprecate and remove the github actions based cache invalidations. 

additionally: makes the GA_TRACKING_ID optional and turns it off in dev.

Closes #281 
Closes #590